### PR TITLE
Add master and release sync action

### DIFF
--- a/.github/workflows/changelog-config.json
+++ b/.github/workflows/changelog-config.json
@@ -17,7 +17,7 @@
             "labels": ["Cleanup"]
         }
     ],
-    "ignore_labels": [],
+    "ignore_labels": ["Auto Generated"],
     "sort": "ASC",
     "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
     "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",

--- a/.github/workflows/sync-release-and-master.yml
+++ b/.github/workflows/sync-release-and-master.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: pull-request
+        uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: "master"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "Sync release with master"
+          pr_body: ":robot: An automated PR to keep master in sync with the release branch"
+          pr_label: "Auto Generated"


### PR DESCRIPTION
## Overview of Changes
Adds an action that will automatically generate a PR whenever anything is merged to `release`.

This will prevent a situation where we merge a hotfix into `release` (but not `master`) and forget to merge it into `master` later as well.

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
