### PR TITLE
Auto check remember me

### DIFF
--- a/resources/views/front/pages/login/login.blade.php
+++ b/resources/views/front/pages/login/login.blade.php
@@ -35,7 +35,7 @@
                     <input class="input-text {{ $errors->any() ? 'input-text--error' : '' }}" name="password" type="password" placeholder="Password" />
                 </div>
                 <div class="form-row">
-                    <label for="remember_me"><input type="checkbox" name="remember_me" id="remember_me"> Stay logged in</label>
+                    <label for="remember_me"><input type="checkbox" name="remember_me" id="remember_me" checked> Stay logged in</label>
                 </div>
                 <div class="form-row">
                     <button class="button button--large button--fill button--primary" type="submit">


### PR DESCRIPTION
## Overview of Changes
The remember me checkbox was supposed to be checked by default

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
