### PR TITLE
Fix null staff player panel bug

### DIFF
--- a/app/Http/Controllers/Panel/MinecraftPlayerLookupController.php
+++ b/app/Http/Controllers/Panel/MinecraftPlayerLookupController.php
@@ -64,6 +64,8 @@ class MinecraftPlayerLookupController extends WebController
         try {
             $mojangPlayer = $api->getUuidOf($alias);
 
+            if ($mojangPlayer == null) return null;
+
             return $this->lookupByUUID($mojangPlayer->getUuid());
         } catch (TooManyRequestsException $e) {
             return null;

--- a/app/Http/Controllers/Panel/MinecraftPlayerLookupController.php
+++ b/app/Http/Controllers/Panel/MinecraftPlayerLookupController.php
@@ -64,7 +64,9 @@ class MinecraftPlayerLookupController extends WebController
         try {
             $mojangPlayer = $api->getUuidOf($alias);
 
-            if ($mojangPlayer == null) return null;
+            if ($mojangPlayer == null) {
+                return null;
+            }
 
             return $this->lookupByUUID($mojangPlayer->getUuid());
         } catch (TooManyRequestsException $e) {

--- a/database/factories/GameBanFactory.php
+++ b/database/factories/GameBanFactory.php
@@ -100,10 +100,11 @@ class GameBanFactory extends Factory
         });
     }
 
-    public function nullBannedBy(): GameBanFactory
+    public function bannedByConsole(): GameBanFactory
     {
         return $this->state(function (array $attributes) {
             return [
+                'staff_player_id' => null,
                 'staff_player_type' => 'minecraft_player',
             ];
         });

--- a/database/factories/GameBanFactory.php
+++ b/database/factories/GameBanFactory.php
@@ -99,4 +99,13 @@ class GameBanFactory extends Factory
             ];
         });
     }
+
+    public function nullBannedBy(): GameBanFactory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'staff_player_type' => 'minecraft_player',
+            ];
+        });
+    }
 }

--- a/resources/views/admin/minecraft-player/show.blade.php
+++ b/resources/views/admin/minecraft-player/show.blade.php
@@ -127,7 +127,15 @@
                                     <i class="fas fa-{{ $ban->is_active ? 'exclamation' : 'clock' }} fa-fw"></i>
                                 </td>
                                 <td>{{ $ban->reason }}</td>
-                                <td><a href="{{ route('front.panel.minecraft-players.show', $ban->staffPlayer) }}">{{ $ban->getStaffName() }}</a></td>
+                                <td>
+                                    @if($ban->staffPlayer == null)
+                                        <span class="badge bg-secondary">Null</span>
+                                    @else
+                                    <a href="{{ route('front.panel.minecraft-players.show', $ban->staffPlayer) }}">
+                                        {{ $ban->getStaffName() }}
+                                    </a>
+                                    @endif
+                                </td>
                                 <td>{{ $ban->expires_at }}</td>
                                 <td>{{ $ban->created_at }}</td>
 

--- a/tests/Feature/PanelMinecraftPlayerLookupTest.php
+++ b/tests/Feature/PanelMinecraftPlayerLookupTest.php
@@ -73,8 +73,28 @@ class PanelMinecraftPlayerLookupTest extends TestCase
             ->assertRedirect(route('front.panel.minecraft-players.show', $mcPlayer));
     }
 
-    public function testLookupOfNonExistentPlayer()
+    public function testLookupOfInvalidPlayer()
     {
+        // this is a player that does not exist in Mojang's database
+        $this->mock(MojangPlayerApi::class, function (MockInterface $mock) {
+            $mock->shouldReceive('getUuidOf')->once()->andReturn(null);
+        });
+
+        $this->actingAs($this->adminAccount())
+            ->post(route('front.panel.minecraft-players.lookup'), [
+                'query' => 'Herobrine',
+            ])
+            ->assertRedirect(route('front.panel.minecraft-players.index'));
+    }
+
+    public function testLookupOfUnknownPlayer()
+    {
+        $this->mock(MojangPlayerApi::class, function (MockInterface $mock) {
+            $mock->shouldReceive('getUuidOf')->once()->andReturn(
+                new MojangPlayer('f84c6a790a4e45e0879bcd49ebd4c4e2', 'Herobrine')
+            );
+        });
+
         $this->actingAs($this->adminAccount())
             ->post(route('front.panel.minecraft-players.lookup'), [
                 'query' => 'Herobrine',

--- a/tests/Feature/PanelMinecraftPlayerLookupTest.php
+++ b/tests/Feature/PanelMinecraftPlayerLookupTest.php
@@ -101,4 +101,22 @@ class PanelMinecraftPlayerLookupTest extends TestCase
             ])
             ->assertRedirect(route('front.panel.minecraft-players.index'));
     }
+
+    public function testEmptyLookupStringEntered()
+    {
+        $this->actingAs($this->adminAccount())
+            ->post(route('front.panel.minecraft-players.lookup'), [
+                'query' => '',
+            ])
+            ->assertRedirect(route('front.panel.minecraft-players.index'));
+    }
+
+    public function testNullLookupStringEntered()
+    {
+        $this->actingAs($this->adminAccount())
+            ->post(route('front.panel.minecraft-players.lookup'), [
+                'query' => null,
+            ])
+            ->assertRedirect(route('front.panel.minecraft-players.index'));
+    }
 }

--- a/tests/Feature/PanelMinecraftPlayerShowTest.php
+++ b/tests/Feature/PanelMinecraftPlayerShowTest.php
@@ -21,4 +21,17 @@ class PanelMinecraftPlayerShowTest extends TestCase
             ->assertOk()
             ->assertSee(GameBan::first()->reason);
     }
+
+    public function testBanWithNullStaffShown()
+    {
+        $bannedPlayer = MinecraftPlayer::factory()
+            ->hasAliases(1)
+            ->has(GameBan::factory()->nullBannedBy())
+            ->create();
+
+        $this->actingAs($this->adminAccount())
+            ->get(route('front.panel.minecraft-players.show', $bannedPlayer))
+            ->assertOk()
+            ->assertSee(GameBan::first()->reason);
+    }
 }

--- a/tests/Feature/PanelMinecraftPlayerShowTest.php
+++ b/tests/Feature/PanelMinecraftPlayerShowTest.php
@@ -26,7 +26,7 @@ class PanelMinecraftPlayerShowTest extends TestCase
     {
         $bannedPlayer = MinecraftPlayer::factory()
             ->hasAliases(1)
-            ->has(GameBan::factory()->nullBannedBy())
+            ->has(GameBan::factory()->bannedByConsole())
             ->create();
 
         $this->actingAs($this->adminAccount())

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use App\Entities\Accounts\Models\Account;
 use App\Entities\Groups\Models\Group;
 use App\Http\Middleware\MfaGate;
+use App\Library\Mojang\Api\MojangPlayerApi;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Session;
@@ -18,6 +19,9 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Mock this class everywhere to prevent it making real requests
+        $this->mock(MojangPlayerApi::class);
     }
 
     protected function disableReauthMiddleware(): TestCase


### PR DESCRIPTION
## Overview of Changes
* Fixes bug when player was banned by null player (maybe this happens when the console does it?) (fixes #413)
* Fixes bug when an unregistered username is entered into lookup (fixes #428)
   * This should've been tested but due to a non-mocked Mojang API instance we were making real queries. To stop this happening again the class is now globally mocked, so it'll error if not locally mocked
* Explicitly test what happens if you lookup "" or `null`

Coverage does decrease in this PR but that's because we're now never invoking the real Mojang API class.

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
