### PR TITLE
Require panel users to have 2fa

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,6 +65,7 @@ class Kernel extends HttpKernel
         'panel' => PanelAccess::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'active-mfa' => \App\Http\Middleware\ActiveMfaSession::class,
+        'requires-mfa' => \App\Http\Middleware\RequiresMfaEnabled::class,
     ];
 
     /**

--- a/app/Http/Middleware/RequiresMfaEnabled.php
+++ b/app/Http/Middleware/RequiresMfaEnabled.php
@@ -4,7 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 /**
  * This middleware prevents the user from accessing a route unless they have 2FA enabled on their account.

--- a/app/Http/Middleware/RequiresMfaEnabled.php
+++ b/app/Http/Middleware/RequiresMfaEnabled.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * This middleware prevents the user from accessing a route unless they have 2FA enabled on their account.
+ */
+class RequiresMfaEnabled
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->user()->is_totp_enabled) {
+            return $next($request);
+        }
+
+        return redirect(route('front.account.security'))
+            ->with('mfa_setup_required', true)
+            ->with('mfa_setup_required_feature', 'the staff panel');
+    }
+}

--- a/resources/views/front/pages/account/account-security.blade.php
+++ b/resources/views/front/pages/account/account-security.blade.php
@@ -5,6 +5,14 @@
 
 @section('contents')
     <div class="contents__body">
+        @if(Session::get('mfa_setup_required', false))
+            <div class="alert alert--error contents__flash">
+                <h3><i class="fas fa-exclamation-circle"></i> 2FA Setup Required</h3>
+                <p>
+                    You need to set up 2FA to use {{ Session::get('mfa_setup_required_feature', 'this feature') }}.
+                </p>
+            </div>
+        @endif
         @if(Session::get('mfa_setup_finished', false))
             <div class="alert alert--success contents__flash">
                 <h3><i class="fas fa-check"></i> 2FA Enabled</h3>

--- a/routes/web.php
+++ b/routes/web.php
@@ -245,7 +245,7 @@ Route::group(['middleware' => 'auth'], function () {
 
 Route::get('bans', 'BanlistController@index')->name('front.banlist');
 
-Route::group(['prefix' => 'panel', 'as' => 'front.panel.', 'namespace' => 'Panel', 'middleware' => ['auth', 'panel']], function () {
+Route::group(['prefix' => 'panel', 'as' => 'front.panel.', 'namespace' => 'Panel', 'middleware' => ['auth', 'panel', 'requires-mfa']], function () {
     Route::view('/', 'admin.index')->name('index');
 
     Route::resource('accounts', 'AccountController')->only(['index', 'show', 'edit', 'update']);

--- a/tests/Feature/PanelTest.php
+++ b/tests/Feature/PanelTest.php
@@ -2,13 +2,36 @@
 
 namespace Tests\Feature;
 
+use App\Entities\Accounts\Models\Account;
+use App\Entities\Groups\Models\Group;
 use Tests\TestCase;
 
 class PanelTest extends TestCase
 {
     public function testGuestCannotSeePanel()
     {
-        $this->get(route('front.panel.accounts.index'))
+        $this->get(route('front.panel.index'))
             ->assertRedirect(route('front.login'));
+    }
+
+    public function testNonMfaUserCannotSeePanel()
+    {
+        $nonMfaAdmin = Account::factory()
+            ->has(Group::factory()->administrator())
+            ->create();
+
+        $this->actingAs($nonMfaAdmin)
+            ->get(route('front.panel.index'))
+            ->assertRedirect(route('front.account.security'))
+            ->assertSessionHas('mfa_setup_required', true);
+    }
+
+    public function testMfaUserCanSeePanel()
+    {
+        $this->withoutExceptionHandling();
+
+        $this->actingAs($this->adminAccount())
+            ->get(route('front.panel.index'))
+            ->assertOk();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,7 @@ abstract class TestCase extends BaseTestCase
         if ($fresh || $this->adminAccount == null) {
             $this->adminAccount = Account::factory()
                 ->has(Group::factory()->administrator())
+                ->hasFinishedTotp()
                 ->create();
         }
 


### PR DESCRIPTION
## Overview of Changes
* Requires users to have 2FA enabled to access the panel

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
