### PR TITLE
Fix backup code logout behaviour

### DIFF
--- a/app/Http/Controllers/MfaBackupController.php
+++ b/app/Http/Controllers/MfaBackupController.php
@@ -30,7 +30,8 @@ class MfaBackupController extends WebController
         $request->user()->resetTotp();
         $request->user()->save();
         $request->user()->notify(new AccountMfaBackupCodeUsedNotification());
-        $request->session()->invalidate();
+        $logoutService->logoutOfPCB();
+        $request->session()->flush();
         $request->session()->regenerateToken();
         $request->session()->flash('mfa_removed', true);
 

--- a/tests/Feature/MfaBackupTest.php
+++ b/tests/Feature/MfaBackupTest.php
@@ -45,6 +45,8 @@ class MfaBackupTest extends TestCase
             ->assertSessionHas('mfa_removed')
             ->assertSessionMissing(MfaGate::NEEDS_MFA_KEY);
 
+        $this->assertGuest();
+
         Notification::assertSentTo($this->mfaAccount, AccountMfaBackupCodeUsedNotification::class);
 
         $account = $this->mfaAccount->refresh();


### PR DESCRIPTION
## Overview of Changes
- Properly aborts the login attempt when a user deactivates MFA with their backup code

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
