### PR TITLE
Fix route caching failing

### DIFF
--- a/app/Http/Middleware/MfaGate.php
+++ b/app/Http/Middleware/MfaGate.php
@@ -18,7 +18,9 @@ class MfaGate
      */
     private array $exclude = [
         'front.login.mfa',
+        'front.login.mfa.submit',
         'front.login.mfa-recover',
+        'front.login.mfa-recover.submit',
     ];
 
     private ResponseFactory $responseFactory;

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -76,14 +76,17 @@ class RouteServiceProvider extends ServiceProvider
         // For backwards compatibility, fallback to v1 if no version specified
         Route::prefix('api')
             ->middleware(['api'])
+            ->name('v0.')
             ->group(base_path('routes/api_v1.php'));
 
         Route::prefix('api/v1')
             ->middleware(['api'])
+            ->name('v1.')
             ->group(base_path('routes/api_v1.php'));
 
         Route::prefix('api/v2')
             ->middleware(['api'])
+            ->name('v1.')
             ->group(base_path('routes/api_v2.php'));
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -86,7 +86,7 @@ class RouteServiceProvider extends ServiceProvider
 
         Route::prefix('api/v2')
             ->middleware(['api'])
-            ->name('v1.')
+            ->name('v2.')
             ->group(base_path('routes/api_v2.php'));
     }
 }

--- a/resources/views/v2/front/pages/account/security/2fa-disable.blade.php
+++ b/resources/views/v2/front/pages/account/security/2fa-disable.blade.php
@@ -18,7 +18,7 @@
                 <p class="form__description">You will no longer need this device to authenticate. You can re-enable 2FA at any time, but
                     you'll be given a different code and backup code.</p>
 
-                <form action="{{ route('front.account.security.disable') }}" method="post" class="toolbar">
+                <form action="{{ route('front.account.security.disable.confirm') }}" method="post" class="toolbar">
                     @csrf
                     @method('DELETE')
                     <a href="{{ route('front.account.security') }}" class="button button--filled button--secondary">Cancel</a>

--- a/resources/views/v2/front/pages/account/security/backup-refresh.blade.php
+++ b/resources/views/v2/front/pages/account/security/backup-refresh.blade.php
@@ -17,7 +17,7 @@
                 <p class="form__description">Are you sure you want to refresh your 2FA backup code?</p>
                 <p class="form__description">The old backup code will stop working and you'll need to safely store the
                     new one.</p>
-                <form action="{{ route('front.account.security.reset-backup') }}" method="post" class="toolbar">
+                <form action="{{ route('front.account.security.reset-backup.confirm') }}" method="post" class="toolbar">
                     @csrf
                     <a href="{{ route('front.account.security') }}"
                        class="button button--filled button--secondary">Cancel</a>

--- a/resources/views/v2/front/pages/login/mfa-backup.blade.php
+++ b/resources/views/v2/front/pages/login/mfa-backup.blade.php
@@ -14,7 +14,7 @@
                 If you've lost access to your 2FA device, you can disable 2FA on your account by entering your backup code.
             </p>
 
-            <form action="{{ route('front.login.mfa-recover') }}" class="form" method="post">
+            <form action="{{ route('front.login.mfa-recover.submit') }}" class="form" method="post">
                 @csrf
                 @method('DELETE')
 

--- a/resources/views/v2/front/pages/login/mfa.blade.php
+++ b/resources/views/v2/front/pages/login/mfa.blade.php
@@ -11,7 +11,7 @@
             @include('v2.front.components.form-error')
 
             <p class="form__description">Enter your current 2FA code to continue</p>
-            <form action="{{ route('front.login.mfa') }}" method="post" class="form">
+            <form action="{{ route('front.login.mfa.submit') }}" method="post" class="form">
                 @csrf
                 <div class="form-row form-row--fluid">
                     <label for="code">Enter Code</label>

--- a/resources/views/v2/front/pages/login/reauth.blade.php
+++ b/resources/views/v2/front/pages/login/reauth.blade.php
@@ -11,7 +11,7 @@
             @include('v2.front.components.form-error')
 
             <p class="form__description">Please re-enter your password to continue</p>
-            <form action="{{ route('password.confirm') }}" method="post" class="form">
+            <form action="{{ route('password.confirm.submit') }}" method="post" class="form">
                 @csrf
                 <div class="form-row">
                     <label for="password">Enter Password</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -135,7 +135,7 @@ Route::prefix('login')->group(function () {
         ->middleware('auth');
 
     Route::post('/reauth', [ReauthController::class, 'process'])
-        ->name('password.confirm')
+        ->name('password.confirm.submit')
         ->middleware(['auth', 'throttle:6,1']);
 
     Route::get('/mfa', [MfaLoginGateController::class, 'create'])
@@ -143,7 +143,7 @@ Route::prefix('login')->group(function () {
         ->middleware(['auth', 'active-mfa']);
 
     Route::post('/mfa', [MfaLoginGateController::class, 'store'])
-        ->name('front.login.mfa')
+        ->name('front.login.mfa.submit')
         ->middleware(['auth', 'active-mfa', 'throttle:6,1']);
 
     Route::get('/mfa/recover', [MfaBackupController::class, 'show'])
@@ -151,7 +151,7 @@ Route::prefix('login')->group(function () {
         ->middleware(['auth', 'active-mfa']);
 
     Route::delete('/mfa/recover', [MfaBackupController::class, 'destroy'])
-        ->name('front.login.mfa-recover')
+        ->name('front.login.mfa-recover.submit')
         ->middleware(['auth', 'active-mfa', 'throttle:6,1']);
 });
 
@@ -243,7 +243,7 @@ Route::group([
             ->middleware('password.confirm');
 
         Route::delete('/mfa/disable', [DisableMfaController::class, 'destroy'])
-            ->name('front.account.security.disable')
+            ->name('front.account.security.disable.confirm')
             ->middleware('password.confirm');
 
         Route::get('/mfa/backup', [ResetBackupController::class, 'show'])
@@ -251,7 +251,7 @@ Route::group([
             ->middleware('password.confirm');
 
         Route::post('/mfa/backup', [ResetBackupController::class, 'update'])
-            ->name('front.account.security.reset-backup')
+            ->name('front.account.security.reset-backup.confirm')
             ->middleware('password.confirm');
     });
 });

--- a/tests/E2E/Console/RouteCacheTest.php
+++ b/tests/E2E/Console/RouteCacheTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\E2E\Console;
+
+use Tests\TestCase;
+
+class RouteCacheTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->artisan('route:clear');
+
+        parent::tearDown();
+    }
+
+    public function test_can_cache_routes()
+    {
+        $this->artisan('route:cache')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/MfaLoginTest.php
+++ b/tests/Feature/MfaLoginTest.php
@@ -45,9 +45,9 @@ class MfaLoginTest extends TestCase
 
         $validCode = $this->google2fa->getCurrentOtp(Crypt::decryptString($this->mfaAccount->totp_secret));
 
-        $this->post(route('front.login.mfa'), [
-            'code' => $validCode,
-        ])->assertSessionHasNoErrors()->assertRedirect();
+        $this->post(route('front.login.mfa.submit'), ['code' => $validCode])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
     }
 
     public function test_cant_submit_wrong_mfa_code()
@@ -55,9 +55,8 @@ class MfaLoginTest extends TestCase
         $this->actingAs($this->mfaAccount)
             ->flagNeedsMfa();
 
-        $this->post(route('front.login.mfa'), [
-            'code' => '000000',
-        ])->assertSessionHasErrors(['code']);
+        $this->post(route('front.login.mfa.submit'), ['code' => '000000'])
+            ->assertSessionHasErrors(['code']);
     }
 
     public function test_cant_submit_no_mfa_code()
@@ -65,7 +64,7 @@ class MfaLoginTest extends TestCase
         $this->actingAs($this->mfaAccount)
             ->flagNeedsMfa();
 
-        $this->post(route('front.login.mfa'), [])
+        $this->post(route('front.login.mfa.submit'), [])
             ->assertSessionHasErrors(['code']);
     }
 
@@ -74,7 +73,7 @@ class MfaLoginTest extends TestCase
         $this->actingAs($this->mfaAccount)
             ->flagNeedsMfa();
 
-        $this->post(route('front.login.mfa'), ['backup_code' => 'abcdefg'])
+        $this->post(route('front.login.mfa.submit'), ['backup_code' => 'abcdefg'])
             ->assertSessionHasErrors(['code']);
     }
 }


### PR DESCRIPTION
## Overview of Changes
Removes duplicate route names so that we can cache the routes in production

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
