### PR TITLE
Add telemetry API for minecraft

### DIFF
--- a/app/Http/Controllers/Api/v1/MinecraftAuthTokenController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftAuthTokenController.php
@@ -17,11 +17,8 @@ final class MinecraftAuthTokenController extends ApiController
 {
     /**
      * Requests an URL that the user can click to link their PCB account.
-     *
-     *
-     * @return void
      */
-    public function store(Request $request)
+    public function store(Request $request): array
     {
         $this->validateRequest($request->all(), [
             'minecraft_uuid' => 'bail|required|string', // TODO: override UUID rule to allow UUIDs without hyphens
@@ -66,11 +63,8 @@ final class MinecraftAuthTokenController extends ApiController
 
     /**
      * Returns the PCB groups that the given UUID belongs to.
-     *
-     *
-     * @return void
      */
-    public function show(Request $request, string $minecraftUUID)
+    public function show(Request $request, string $minecraftUUID): array
     {
         $uuid = str_replace('-', '', $minecraftUUID);
 

--- a/app/Http/Controllers/Api/v1/MinecraftTelemetryController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftTelemetryController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\ApiController;
+use Domain\MinecraftTelemetry\UseCases\UpdateSeenMinecraftPlayerUseCase;
+use Illuminate\Http\Request;
+
+final class MinecraftTelemetryController extends ApiController
+{
+    public function playerSeen(
+        Request $request,
+        UpdateSeenMinecraftPlayerUseCase $updateSeenMinecraftPlayer,
+    ) {
+        $this->validateRequest($request->all(), [
+            'uuid' => 'required|string',
+            'alias' => 'required|string'
+        ]);
+        $updateSeenMinecraftPlayer->execute(
+            uuid: $request->get('uuid'),
+            alias: $request->get('alias'),
+        );
+    }
+}

--- a/domain/MinecraftTelemetry/UseCases/UpdateSeenMinecraftPlayerUseCase.php
+++ b/domain/MinecraftTelemetry/UseCases/UpdateSeenMinecraftPlayerUseCase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Domain\MinecraftTelemetry\UseCases;
+
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Repositories\MinecraftPlayerAliasRepository;
+use Shared\PlayerLookup\Entities\PlayerIdentifier;
+use Shared\PlayerLookup\PlayerLookup;
+
+final class UpdateSeenMinecraftPlayerUseCase
+{
+    public function __construct(
+        private readonly PlayerLookup $playerLookup,
+        private readonly MinecraftPlayerAliasRepository $aliasRepository,
+    ) {}
+
+    public function execute(string $uuid, string $alias): void
+    {
+        $player = $this->playerLookup->findOrCreate(
+            identifier: PlayerIdentifier::minecraftUUID($uuid)
+        );
+
+        /** @var MinecraftPlayer $player */
+        $minecraftPlayer = $player->getRawModel();
+
+        $now = now();
+
+        $minecraftPlayer->last_synced_at = $now;
+        $minecraftPlayer->save();
+
+        if (! $minecraftPlayer->hasAlias($alias)) {
+            $this->aliasRepository->store(
+                minecraftPlayerId: $minecraftPlayer->getKey(),
+                alias: $alias,
+                registeredAt: $now,
+            );
+        }
+    }
+}

--- a/entities/Models/Eloquent/MinecraftPlayer.php
+++ b/entities/Models/Eloquent/MinecraftPlayer.php
@@ -3,6 +3,7 @@
 namespace Entities\Models\Eloquent;
 
 use App\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,6 +15,7 @@ use Shared\PlayerLookup\Contracts\Player;
  * @property int account_id
  * @property ?Account account
  * @property ?Carbon last_synced_at
+ * @property Collection aliases
  */
 final class MinecraftPlayer extends Model implements Player
 {
@@ -75,6 +77,13 @@ final class MinecraftPlayer extends Model implements Player
         $this->last_synced_at = $this->freshTimestamp();
 
         return $this->save();
+    }
+
+    public function hasAlias(string $alias): bool
+    {
+        return $this->aliases
+            ->where('alias', $alias)
+            ->isNotEmpty();
     }
 
     /** ************************************************

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\v1\GameBanV1Controller;
 use App\Http\Controllers\Api\v1\GroupApiController;
 use App\Http\Controllers\Api\v1\MinecraftAuthTokenController;
+use App\Http\Controllers\Api\v1\MinecraftTelemetryController;
 use App\Http\Controllers\Api\v1\StripeWebhookController;
 use Illuminate\Support\Facades\Route;
 
@@ -35,4 +36,10 @@ Route::prefix('auth')->group(function () {
 
 Route::prefix('groups')->group(function () {
     Route::get('/', [GroupApiController::class, 'getAll']);
+});
+
+Route::prefix('minecraft')->group(function () {
+    Route::prefix('telemetry')->group(function () {
+        Route::get('seen', [MinecraftTelemetryController::class, 'playerSeen']);
+    });
 });

--- a/shared/PlayerLookup/Entities/PlayerIdentifier.php
+++ b/shared/PlayerLookup/Entities/PlayerIdentifier.php
@@ -3,6 +3,7 @@
 namespace Shared\PlayerLookup\Entities;
 
 use Entities\Models\GameIdentifierType;
+use Shared\PlayerLookup\Exceptions\InvalidMinecraftUUIDException;
 
 final class PlayerIdentifier
 {
@@ -15,8 +16,14 @@ final class PlayerIdentifier
         public GameIdentifierType $gameIdentifierType,
     ) {}
 
+    /**
+     * @throws InvalidMinecraftUUIDException if UUID string is empty
+     */
     public static function minecraftUUID(string $uuid): PlayerIdentifier
     {
+        if (empty($uuid)) {
+            throw new InvalidMinecraftUUIDException();
+        }
         return new PlayerIdentifier(
             key: $uuid,
             gameIdentifierType: GameIdentifierType::MINECRAFT_UUID,

--- a/shared/PlayerLookup/Exceptions/InvalidMinecraftUUIDException.php
+++ b/shared/PlayerLookup/Exceptions/InvalidMinecraftUUIDException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shared\PlayerLookup\Exceptions;
+
+use App\Exceptions\Http\PredefinedHttpException;
+
+final class InvalidMinecraftUUIDException extends PredefinedHttpException
+{
+    protected string $id = 'invalid_minecraft_uuid';
+
+    protected string $errorMessage = 'The given UUID is not valid';
+
+    protected int $status = 400;
+}

--- a/tests/Unit/Domain/Login/UseCases/LoginUseCaseTest.php
+++ b/tests/Unit/Domain/Login/UseCases/LoginUseCaseTest.php
@@ -13,7 +13,6 @@ use Entities\Repositories\AccountRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
-use Shared\ExternalAccounts\Sync\ExternalAccountSync;
 use Tests\TestCase;
 
 class LoginUseCaseTest extends TestCase

--- a/tests/Unit/Domain/MinecraftTelemetry/UseCases/UpdateSeenMinecraftPlayerUseCaseTest.php
+++ b/tests/Unit/Domain/MinecraftTelemetry/UseCases/UpdateSeenMinecraftPlayerUseCaseTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Domain\MinecraftTelemetry\UseCases;
+
+use Domain\MinecraftTelemetry\UseCases\UpdateSeenMinecraftPlayerUseCase;
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Models\Eloquent\MinecraftPlayerAlias;
+use Entities\Repositories\MinecraftPlayerAliasRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shared\PlayerLookup\PlayerLookup;
+use Tests\TestCase;
+
+class UpdateSeenMinecraftPlayerUseCaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PlayerLookup $playerLookup;
+    private MinecraftPlayerAliasRepository $aliasRepository;
+    private UpdateSeenMinecraftPlayerUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->playerLookup = \Mockery::mock(PlayerLookup::class);
+        $this->aliasRepository = \Mockery::mock(MinecraftPlayerAliasRepository::class);
+
+        $this->useCase = new UpdateSeenMinecraftPlayerUseCase(
+            playerLookup: $this->playerLookup,
+            aliasRepository: $this->aliasRepository,
+        );
+    }
+
+    public function test_updates_last_seen_date()
+    {
+        $now = $this->setTestNow();
+        $before = $now->copy()->subWeek();
+
+        $player = MinecraftPlayer::factory()->create([
+            'uuid' => 'uuid',
+            'last_synced_at' => $before,
+        ]);
+        MinecraftPlayerAlias::factory()->for($player)->create([
+            'alias' => 'alias',
+        ]);
+
+        $this->playerLookup
+            ->shouldReceive('findOrCreate')
+            ->andReturn($player);
+
+        $this->assertEquals(
+            expected: $before,
+            actual: $player->last_synced_at,
+        );
+
+        $this->useCase->execute(uuid: 'uuid', alias: 'alias');
+
+        $this->assertEquals(
+            expected: $now,
+            actual: $player->last_synced_at,
+        );
+    }
+
+    public function test_creates_alias_if_player_changed_alias()
+    {
+        $now = $this->setTestNow();
+
+        $player = MinecraftPlayer::factory()->create([
+            'uuid' => 'uuid',
+            'last_synced_at' => $now->copy()->subWeek(),
+        ]);
+        MinecraftPlayerAlias::factory()->for($player)->create([
+            'alias' => 'old_alias',
+        ]);
+
+        $this->playerLookup
+            ->shouldReceive('findOrCreate')
+            ->andReturn($player);
+
+        $this->aliasRepository
+            ->shouldReceive('store')
+            ->andReturn(new MinecraftPlayerAlias());
+
+        $this->useCase->execute(uuid: 'uuid', alias: 'new_alias');
+    }
+}


### PR DESCRIPTION
## Overview of Changes

Adds a new endpoint for PCBridge to call that will let us know when a player was last seen, and what their Minecraft username was at the time.

The endpoint will be called when the player connects and disconnects from the server

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
