### PR TITLE
Add scope for telemetry endpoint

### DIFF
--- a/app/Http/Controllers/Api/v2/GameBanV2Controller.php
+++ b/app/Http/Controllers/Api/v2/GameBanV2Controller.php
@@ -47,7 +47,7 @@ final class GameBanV2Controller extends ApiController
         }
 
         $ban = $createBanUseCase->execute(
-            serverId: $request->get('server_id'),
+            serverId: $request->token->server_id,
             bannedPlayerIdentifier: new PlayerIdentifier(
                 key: $request->get('banned_player_id'),
                 gameIdentifierType: GameIdentifierType::tryFrom($request->get('banned_player_type')),

--- a/domain/ServerTokens/ScopeKey.php
+++ b/domain/ServerTokens/ScopeKey.php
@@ -13,4 +13,6 @@ enum ScopeKey: string
 
     case ACCOUNT_BALANCE_SHOW = 'balance:show';
     case ACCOUNT_BALANCE_DEDUCT = 'balance:deduct';
+
+    case TELEMETRY = 'telemetry:all';
 }

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -3,7 +3,6 @@
 use App\Http\Controllers\Api\v1\GameBanV1Controller;
 use App\Http\Controllers\Api\v1\GroupApiController;
 use App\Http\Controllers\Api\v1\MinecraftAuthTokenController;
-use App\Http\Controllers\Api\v1\MinecraftTelemetryController;
 use App\Http\Controllers\Api\v1\StripeWebhookController;
 use Illuminate\Support\Facades\Route;
 
@@ -36,10 +35,4 @@ Route::prefix('auth')->group(function () {
 
 Route::prefix('groups')->group(function () {
     Route::get('/', [GroupApiController::class, 'getAll']);
-});
-
-Route::prefix('minecraft')->group(function () {
-    Route::prefix('telemetry')->group(function () {
-        Route::get('seen', [MinecraftTelemetryController::class, 'playerSeen']);
-    });
 });

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\v1\MinecraftBalanceController;
 use App\Http\Controllers\Api\v1\MinecraftDonationTierController;
+use App\Http\Controllers\Api\v1\MinecraftTelemetryController;
 use App\Http\Controllers\Api\v2\GameBanV2Controller;
 use Domain\ServerTokens\ScopeKey;
 use Illuminate\Support\Facades\Route;
@@ -18,24 +19,20 @@ use Library\Environment\Environment;
 |
 */
 
-$isBanV2Enabled = ! Environment::isProduction();
-
-if ($isBanV2Enabled) {
-    Route::prefix('bans')->group(function () {
-        Route::middleware(
-            'server-token:'.ScopeKey::BAN_UPDATE->value,
-        )->group(function () {
-            Route::post('ban', [GameBanV2Controller::class, 'ban']);
-            Route::post('unban', [GameBanV2Controller::class, 'unban']);
-        });
-
-        Route::middleware([
-            'server-token:'.ScopeKey::BAN_LOOKUP->value,
-        ])->group(function () {
-            Route::post('status', [GameBanV2Controller::class, 'status']);
-        });
+Route::prefix('bans')->group(function () {
+    Route::middleware(
+        'server-token:'.ScopeKey::BAN_UPDATE->value,
+    )->group(function () {
+        Route::post('ban', [GameBanV2Controller::class, 'ban']);
+        Route::post('unban', [GameBanV2Controller::class, 'unban']);
     });
-}
+
+    Route::middleware([
+        'server-token:'.ScopeKey::BAN_LOOKUP->value,
+    ])->group(function () {
+        Route::post('status', [GameBanV2Controller::class, 'status']);
+    });
+});
 
 Route::prefix('minecraft/{minecraftUUID}')->group(function () {
     Route::get('donation-tiers', [MinecraftDonationTierController::class, 'show']);
@@ -50,5 +47,13 @@ Route::prefix('minecraft/{minecraftUUID}')->group(function () {
         'server-token:'.ScopeKey::ACCOUNT_BALANCE_DEDUCT->value
     )->group(function () {
         Route::post('balance/deduct', [MinecraftBalanceController::class, 'deduct']);
+    });
+});
+
+Route::middleware(
+    'server-token:'.ScopeKey::TELEMETRY->value
+)->group(function () {
+    Route::prefix('minecraft/telemetry')->group(function () {
+        Route::get('seen', [MinecraftTelemetryController::class, 'playerSeen']);
     });
 });

--- a/tests/E2E/API/APIMinecraftTelemetryTest.php
+++ b/tests/E2E/API/APIMinecraftTelemetryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\E2E\API;
+
+use Domain\ServerTokens\ScopeKey;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\E2ETestCase;
+
+class APIMinecraftTelemetryTest extends E2ETestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = 'api/v2/telemetry/minecraft/seen';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerToken();
+    }
+
+    public function test_requires_scope()
+    {
+        $this->withAuthorizationServerToken()
+            ->getJson(self::ENDPOINT, ['uuid' => 'uuid', 'alias' => 'alias'])
+            ->assertUnauthorized();
+
+        $this->authoriseTokenFor(ScopeKey::TELEMETRY);
+
+        $this->withAuthorizationServerToken()
+            ->getJson(self::ENDPOINT, ['uuid' => 'uuid', 'alias' => 'alias'])
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
## Overview of Changes

Adds a authorization scope for using the telemetry endpoints.
Also enables the v2 ban endpoints

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
