### PR TITLE
Remove the `--skip-column-statistics` flag

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -57,11 +57,6 @@ return [
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
-
-            // https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
-            'dump' => [
-                'add_extra_option' => '--column_statistics=0',
-            ],
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -60,7 +60,7 @@ return [
 
             // https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
             'dump' => [
-                'add_extra_option' => '--skip-column-statistics',
+                'add_extra_option' => '--column_statistics=0',
             ],
         ],
 


### PR DESCRIPTION
## Overview of Changes

Seems to be the cause of the db backup failure in production (fixes #579)

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
