### PR TITLE
Fix `player_id_type` validation always failing

### DIFF
--- a/app/Http/Controllers/Api/v1/GameBanV1Controller.php
+++ b/app/Http/Controllers/Api/v1/GameBanV1Controller.php
@@ -54,10 +54,10 @@ final class GameBanV1Controller extends ApiController
         $serverKey = $this->getServerKeyFromHeader($request);
 
         $this->validateRequest($request->all(), [
-            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'player_id' => 'required|max:60',
             'player_alias' => 'required',
-            'staff_id_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'staff_id_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'staff_id' => 'required|max:60',
             'reason' => 'string',
             'expires_at' => 'integer',
@@ -98,9 +98,9 @@ final class GameBanV1Controller extends ApiController
         $serverKey = $this->getServerKeyFromHeader($request);
 
         $this->validateRequest($request->all(), [
-            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'player_id' => 'required',
-            'staff_id_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'staff_id_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'staff_id' => 'required',
         ], [
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
@@ -122,7 +122,7 @@ final class GameBanV1Controller extends ApiController
         $serverKey = $this->getServerKeyFromHeader($request);
 
         $this->validateRequest($request->all(), [
-            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'player_id_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'player_id' => 'required',
         ], [
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',

--- a/app/Http/Controllers/Api/v2/GameBanV2Controller.php
+++ b/app/Http/Controllers/Api/v2/GameBanV2Controller.php
@@ -30,10 +30,10 @@ final class GameBanV2Controller extends ApiController
         $this->validateRequest($request->all(), [
             'server_id' => 'required|integer',
             'banned_player_id' => 'required|max:60',
-            'banned_player_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'banned_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'banned_player_alias' => 'required',
             'banner_player_id' => 'required|max:60',
-            'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'reason' => 'string',
             'expires_at' => 'integer',
             'is_global_ban' => 'required|boolean',
@@ -76,9 +76,9 @@ final class GameBanV2Controller extends ApiController
     ): GameUnbanResource {
         $this->validateRequest($request->all(), [
             'banned_player_id' => 'required|max:60',
-            'banned_player_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'banned_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'banner_player_id' => 'required|max:60',
-            'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
         ], [
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
         ]);
@@ -106,7 +106,7 @@ final class GameBanV2Controller extends ApiController
     ): GameBanResource|array {
         $this->validateRequest($request->all(), [
             'player_id' => 'required|max:60',
-            'player_type' => ['required', Rule::in(PlayerIdentifierType::allJoined())],
+            'player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
         ], [
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
         ]);

--- a/helpers/ValueJoinable.php
+++ b/helpers/ValueJoinable.php
@@ -27,4 +27,11 @@ trait ValueJoinable
             ->map(fn ($c) => $c->value)
             ->join(glue: ',');
     }
+
+    public static function values(): array
+    {
+        return collect(self::cases())
+            ->map(fn ($c) => $c->value)
+            ->toArray();
+    }
 }


### PR DESCRIPTION
## Overview of Changes

Fixes ban APIs returning 400 errors due to `player_id_type` validation always failing.

Not sure why Laravel's `Rule::in(...)` suddenly stopped supporting comma-delimited strings though... 🤔 

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
