### PR TITLE
Fix incorrect auditing for accounts

### DIFF
--- a/entities/Models/Eloquent/Account.php
+++ b/entities/Models/Eloquent/Account.php
@@ -63,14 +63,11 @@ final class Account extends Authenticatable
         'deleted',
         'synced',
     ];
-    protected static $syncRecordFields = [
-        'groups' => 'name',
-    ];
     protected $logged = [
         'email',
         'username',
         'activated',
-        'groups',
+        'group_names',
     ];
     protected $dates = [
         'created_at',
@@ -108,6 +105,11 @@ final class Account extends Authenticatable
             foreignPivotKey: 'account_id',
             relatedPivotKey: 'group_id',
         );
+    }
+
+    public function getGroupNamesAttribute()
+    {
+        return $this->groups()->pluck('name');
     }
 
     public function donations(): HasMany

--- a/entities/Models/Eloquent/Account.php
+++ b/entities/Models/Eloquent/Account.php
@@ -107,7 +107,7 @@ final class Account extends Authenticatable
         );
     }
 
-    public function getGroupNamesAttribute()
+    public function getGroupNamesAttribute(): Collection
     {
         return $this->groups()->pluck('name');
     }

--- a/library/Auditing/Traits/LogsActivity.php
+++ b/library/Auditing/Traits/LogsActivity.php
@@ -67,7 +67,6 @@ trait LogsActivity
     {
         $oldValues = (new static())->setRawAttributes($model->getRawOriginal());
         $model->oldAttributes = static::logChanges($oldValues);
-        dump($model->oldAttributes);
     }
 
     /**

--- a/library/Auditing/Traits/LogsActivity.php
+++ b/library/Auditing/Traits/LogsActivity.php
@@ -18,6 +18,9 @@ trait LogsActivity
     {
         // If this model should record the synced event
         if (static::eventsToBeRecorded()->contains('synced')) {
+            // Remove the event from the to be recorded list to prevent it being handled normally
+            static::forgetRecordEvent('synced');
+
             // On the syncing event (i.e. before the sync is done), store the old value
             static::syncing(function (Model $model) {
                 static::addOldAttributes($model);
@@ -89,5 +92,16 @@ trait LogsActivity
         }
 
         return collect(static::$syncRecordFields)->get($relationship, 'id');
+    }
+
+    /**
+     * Remove an event from the to be recorded list
+     *
+     * @param $event
+     * @return void
+     */
+    private static function forgetRecordEvent($event): void
+    {
+        static::$recordEvents = static::eventsToBeRecorded()->reject($event)->toArray();
     }
 }

--- a/library/Auditing/Traits/LogsActivity.php
+++ b/library/Auditing/Traits/LogsActivity.php
@@ -78,6 +78,8 @@ trait LogsActivity
      */
     private static function forgetRecordEvent($event): void
     {
-        static::$recordEvents = static::eventsToBeRecorded()->reject($event)->toArray();
+        if (isset(static::$recordEvents)) {
+            static::$recordEvents = static::eventsToBeRecorded()->reject($event)->toArray();
+        }
     }
 }

--- a/library/Auditing/Traits/LogsActivity.php
+++ b/library/Auditing/Traits/LogsActivity.php
@@ -4,7 +4,6 @@ namespace Library\Auditing\Traits;
 
 use Altek\Eventually\Eventually;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
 use Spatie\Activitylog\Traits\LogsActivity as ParentLogsActivity;
 
@@ -12,44 +11,6 @@ trait LogsActivity
 {
     use ParentLogsActivity {
         ParentLogsActivity::bootLogsActivity as parentBootLogsActivity;
-    }
-
-    private static function registerEventuallyLogging(): void
-    {
-        // If this model should record the synced event
-        if (static::eventsToBeRecorded()->contains('synced')) {
-            // Remove the event from the to be recorded list to prevent it being handled normally
-            static::forgetRecordEvent('synced');
-
-            // On the syncing event (i.e. before the sync is done), store the old value
-            static::syncing(function (Model $model) {
-                static::addOldAttributes($model);
-            });
-
-            static::synced(function (Model $model, string $relation) {
-                // If no loggable changes have been made, and this model is not configured
-                // to submit empty logs, then skip
-                $attrs = $model->attributeValuesToBeLogged('updated');
-                if ($model->isLogEmpty($attrs) && ! $model->activitylogOptions->submitEmptyLogs) {
-                    return;
-                }
-
-                // For each attribute, if it's a collection, get the model attribute specified
-                $attrs = collect($attrs)
-                    ->map(fn (array $element) => collect($element)
-                        ->map(fn ($attribute) => ($attribute instanceof Collection) ?
-                            $attribute->pluck(static::getRelationshipField($relation)) : $attribute
-                        ))
-                    ->toArray();
-
-                app(ActivityLogger::class)
-                    ->useLog($model->getLogNameToUse())
-                    ->performedOn($model)
-                    ->withProperties($attrs)
-                    ->event('synced')
-                    ->log($model->getDescriptionForEvent("{$relation} update"));
-            });
-        }
     }
 
     /**
@@ -67,6 +28,35 @@ trait LogsActivity
         self::parentBootLogsActivity();
     }
 
+    private static function registerEventuallyLogging(): void
+    {
+        if (static::eventsToBeRecorded()->contains('synced')) {
+            // On the syncing event (i.e. before the sync is done), store the old value
+            static::syncing(function (Model $model) {
+                static::addOldAttributes($model);
+            });
+
+            // Remove the event from the to be recorded list to prevent it being handled normally
+            static::forgetRecordEvent('synced');
+
+            static::synced(function (Model $model, string $relation) {
+                // If no loggable changes have been made, and this model is not configured
+                // to submit empty logs, then skip
+                $attrs = $model->attributeValuesToBeLogged('updated');
+                if ($model->isLogEmpty($attrs) && ! $model->activitylogOptions->submitEmptyLogs) {
+                    return;
+                }
+
+                app(ActivityLogger::class)
+                    ->useLog($model->getLogNameToUse())
+                    ->performedOn($model)
+                    ->withProperties($attrs)
+                    ->event('synced')
+                    ->log($model->getDescriptionForEvent("{$relation} update"));
+            });
+        }
+    }
+
     /**
      * Set old attributes for this event
      *
@@ -77,21 +67,7 @@ trait LogsActivity
     {
         $oldValues = (new static())->setRawAttributes($model->getRawOriginal());
         $model->oldAttributes = static::logChanges($oldValues);
-    }
-
-    /**
-     * Get the desired attribute to log for a relationship
-     *
-     * @param $relationship string the relationship method
-     * @return mixed
-     */
-    private static function getRelationshipField(string $relationship): mixed
-    {
-        if (! isset(static::$syncRecordFields)) {
-            return 'id';
-        }
-
-        return collect(static::$syncRecordFields)->get($relationship, 'id');
+        dump($model->oldAttributes);
     }
 
     /**


### PR DESCRIPTION
## Overview of Changes
* Many to many relationships are no longer automatically logged. Instead, we just create an attribute which returns a list
  * Fixes accounts having empty audit entries on login/logout
* Fixes accounts having duplicated audits upon group updates

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
