### PR TITLE
Update to Ban API v2

### DIFF
--- a/app/Http/Controllers/Api/v2/GameBanV2Controller.php
+++ b/app/Http/Controllers/Api/v2/GameBanV2Controller.php
@@ -112,7 +112,7 @@ final class GameBanV2Controller extends ApiController
         $ban = $getBan->execute(
             playerIdentifier: new PlayerIdentifier(
                 key: $request->get('player_id'),
-                gameIdentifierType: PlayerIdentifierType::tryFrom($request->get('player_id_type')),
+                gameIdentifierType: PlayerIdentifierType::tryFrom($request->get('player_type')),
             ),
         );
 

--- a/app/Http/Controllers/Api/v2/GameBanV2Controller.php
+++ b/app/Http/Controllers/Api/v2/GameBanV2Controller.php
@@ -33,6 +33,7 @@ final class GameBanV2Controller extends ApiController
             'banned_player_alias' => 'required',
             'banner_player_id' => 'required|max:60',
             'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
+            'banner_player_alias' => 'required',
             'reason' => 'string',
             'expires_at' => 'integer',
         ], [

--- a/app/Http/Controllers/Api/v2/GameBanV2Controller.php
+++ b/app/Http/Controllers/Api/v2/GameBanV2Controller.php
@@ -25,10 +25,9 @@ final class GameBanV2Controller extends ApiController
      */
     public function ban(
         Request $request,
-        CreateBanUseCase $createBanUseCase,
+        CreateBanUseCase $createBan,
     ): GameBanResource {
         $this->validateRequest($request->all(), [
-            'server_id' => 'required|integer',
             'banned_player_id' => 'required|max:60',
             'banned_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'banned_player_alias' => 'required',
@@ -36,7 +35,6 @@ final class GameBanV2Controller extends ApiController
             'banner_player_type' => ['required', Rule::in(PlayerIdentifierType::values())],
             'reason' => 'string',
             'expires_at' => 'integer',
-            'is_global_ban' => 'required|boolean',
         ], [
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
         ]);
@@ -46,7 +44,7 @@ final class GameBanV2Controller extends ApiController
             $expiresAt = Carbon::createFromTimestamp($expiresAt);
         }
 
-        $ban = $createBanUseCase->execute(
+        $ban = $createBan->execute(
             serverId: $request->token->server_id,
             bannedPlayerIdentifier: new PlayerIdentifier(
                 key: $request->get('banned_player_id'),
@@ -58,7 +56,6 @@ final class GameBanV2Controller extends ApiController
                 gameIdentifierType: PlayerIdentifierType::tryFrom($request->get('banner_player_type')),
             ),
             bannerPlayerAlias: $request->get('banner_player_alias'),
-            isGlobalBan: $request->get('is_global_ban', true),
             banReason: $request->get('reason'),
             expiresAt: $expiresAt,
         );
@@ -72,7 +69,7 @@ final class GameBanV2Controller extends ApiController
      */
     public function unban(
         Request $request,
-        CreateUnbanUseCase $createUnbanUseCase,
+        CreateUnbanUseCase $createUnban,
     ): GameUnbanResource {
         $this->validateRequest($request->all(), [
             'banned_player_id' => 'required|max:60',
@@ -83,7 +80,7 @@ final class GameBanV2Controller extends ApiController
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
         ]);
 
-        $unban = $createUnbanUseCase->execute(
+        $unban = $createUnban->execute(
             bannedPlayerIdentifier: new PlayerIdentifier(
                 key: $request->get('banned_player_id'),
                 gameIdentifierType: PlayerIdentifierType::tryFrom($request->Get('banned_player_type')),
@@ -102,7 +99,7 @@ final class GameBanV2Controller extends ApiController
      */
     public function status(
         Request $request,
-        GetBanUseCase $getBanUseCase,
+        GetBanUseCase $getBan,
     ): GameBanResource|array {
         $this->validateRequest($request->all(), [
             'player_id' => 'required|max:60',
@@ -111,7 +108,7 @@ final class GameBanV2Controller extends ApiController
             'in' => 'Invalid :attribute given. Must be ['.PlayerIdentifierType::allJoined().']',
         ]);
 
-        $ban = $getBanUseCase->execute(
+        $ban = $getBan->execute(
             playerIdentifier: new PlayerIdentifier(
                 key: $request->get('player_id'),
                 gameIdentifierType: PlayerIdentifierType::tryFrom($request->get('player_id_type')),

--- a/app/Http/Middleware/RequiresServerTokenScope.php
+++ b/app/Http/Middleware/RequiresServerTokenScope.php
@@ -45,7 +45,8 @@ class RequiresServerTokenScope
         return $next($request);
     }
 
-    public static function middleware(ScopeKey $scopeKey): string {
+    public static function middleware(ScopeKey $scopeKey): string
+    {
         return 'server-token:'.$scopeKey->value;
     }
 }

--- a/app/Http/Middleware/RequiresServerTokenScope.php
+++ b/app/Http/Middleware/RequiresServerTokenScope.php
@@ -36,7 +36,7 @@ class RequiresServerTokenScope
 
         $hasScope = $token->scopes->contains(fn ($s) => $s->scope === $scope);
         if (! $hasScope) {
-            abort(401);
+            abort(403);
         }
 
         $request->token = $token;

--- a/app/Http/Middleware/RequiresServerTokenScope.php
+++ b/app/Http/Middleware/RequiresServerTokenScope.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Domain\ServerTokens\ScopeKey;
 use Entities\Models\Eloquent\ServerToken;
 use Illuminate\Http\Request;
 
@@ -42,5 +43,9 @@ class RequiresServerTokenScope
         $request->token = $token;
 
         return $next($request);
+    }
+
+    public static function middleware(ScopeKey $scopeKey): string {
+        return 'server-token:'.$scopeKey->value;
     }
 }

--- a/database/factories/GameBanFactory.php
+++ b/database/factories/GameBanFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Entities\Models\Eloquent\GameBan;
 use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Models\Eloquent\Server;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class GameBanFactory extends Factory
@@ -112,5 +113,10 @@ class GameBanFactory extends Factory
     public function bannedPlayer(MinecraftPlayer|Factory $player): GameBanFactory
     {
         return $this->for($player, 'bannedPlayer');
+    }
+
+    public function server(Server|Factory $server): GameBanFactory
+    {
+        return $this->for($server, 'server');
     }
 }

--- a/domain/Bans/UseCases/CreateBanUseCase.php
+++ b/domain/Bans/UseCases/CreateBanUseCase.php
@@ -23,7 +23,6 @@ final class CreateBanUseCase
      * @param  string  $bannedPlayerAlias Name of the player at the time of ban
      * @param  PlayerIdentifier  $bannerPlayerIdentifier Player that created the ban
      * @param  string  $bannerPlayerAlias Name of the player that created the ban at the time
-     * @param  bool  $isGlobalBan Whether the player will be banned from all servers, or just the server they were banned on
      * @param  string|null  $banReason Reason the player was banned
      * @param  Carbon|null  $expiresAt Date the ban will expire. If null, ban is permanent
      * @return GameBan
@@ -36,7 +35,6 @@ final class CreateBanUseCase
         string $bannedPlayerAlias,
         PlayerIdentifier $bannerPlayerIdentifier,
         string $bannerPlayerAlias,
-        bool $isGlobalBan,
         ?string $banReason,
         ?Carbon $expiresAt,
     ): GameBan {
@@ -60,7 +58,6 @@ final class CreateBanUseCase
             bannedPlayerId: $bannedPlayer->getKey(),
             bannedPlayerAlias: $bannedPlayerAlias,
             bannerPlayerId: $bannerPlayer->getKey(),
-            isGlobalBan: $isGlobalBan,
             reason: $banReason,
             expiresAt: $expiresAt,
         );

--- a/domain/Bans/UseCases/CreateBanUseCase.php
+++ b/domain/Bans/UseCases/CreateBanUseCase.php
@@ -72,9 +72,9 @@ final class CreateBanUseCase
                 expiresAt: $expiresAt,
             );
             DB::commit();
+
             return $ban;
-        }
-        catch(\Throwable $e) {
+        } catch (\Throwable $e) {
             DB::rollBack();
             throw $e;
         }

--- a/domain/Bans/UseCases/CreateUnbanUseCase.php
+++ b/domain/Bans/UseCases/CreateUnbanUseCase.php
@@ -13,9 +13,9 @@ use Shared\PlayerLookup\PlayerLookup;
 class CreateUnbanUseCase
 {
     public function __construct(
-        private GameBanRepository $gameBanRepository,
-        private GameUnbanRepository $gameUnbanRepository,
-        private PlayerLookup $playerLookup,
+        private readonly GameBanRepository $gameBanRepository,
+        private readonly GameUnbanRepository $gameUnbanRepository,
+        private readonly PlayerLookup $playerLookup,
     ) {
     }
 
@@ -31,7 +31,7 @@ class CreateUnbanUseCase
         PlayerIdentifier $unbannerPlayerIdentifier,
     ): GameUnban {
         $bannedPlayer = $this->playerLookup->findOrCreate($bannedPlayerIdentifier);
-        $existingBan = $this->gameBanRepository->firstActiveBan($bannedPlayer)
+        $existingBan = $this->gameBanRepository->firstActiveBan(player: $bannedPlayer, skipTempBans: false)
             ?? throw new PlayerNotBannedException();
 
         $unbannerPlayer = $this->playerLookup->findOrCreate(identifier: $unbannerPlayerIdentifier);

--- a/domain/Bans/UseCases/GetBanUseCase.php
+++ b/domain/Bans/UseCases/GetBanUseCase.php
@@ -10,8 +10,8 @@ use Shared\PlayerLookup\PlayerLookup;
 final class GetBanUseCase
 {
     public function __construct(
-        private GameBanRepository $gameBanRepository,
-        private PlayerLookup $playerLookup,
+        private readonly GameBanRepository $gameBanRepository,
+        private readonly PlayerLookup $playerLookup,
     ) {
     }
 
@@ -24,6 +24,6 @@ final class GetBanUseCase
     ): ?GameBan {
         $mcPlayer = $this->playerLookup->findOrCreate($playerIdentifier);
 
-        return $this->gameBanRepository->firstActiveBan($mcPlayer);
+        return $this->gameBanRepository->firstActiveBan(player: $mcPlayer, skipTempBans: false);
     }
 }

--- a/domain/Bans/UseCases/LookupBanUseCase.php
+++ b/domain/Bans/UseCases/LookupBanUseCase.php
@@ -38,7 +38,7 @@ class LookupBanUseCase
             throw new PlayerNotBannedException();
         }
 
-        $gameBan = $this->gameBanRepository->firstActiveBan($mcPlayer);
+        $gameBan = $this->gameBanRepository->firstActiveBan(player: $mcPlayer, skipTempBans: false);
 
         if ($gameBan === null) {
             throw new PlayerNotBannedException();

--- a/repositories/GameBanRepository.php
+++ b/repositories/GameBanRepository.php
@@ -16,7 +16,6 @@ class GameBanRepository
         int $bannedPlayerId,
         string $bannedPlayerAlias,
         int $bannerPlayerId,
-        bool $isGlobalBan,
         ?string $reason,
         ?Carbon $expiresAt,
     ): GameBan {
@@ -27,7 +26,7 @@ class GameBanRepository
             'staff_player_id' => $bannerPlayerId,
             'reason' => $reason,
             'is_active' => true,
-            'is_global_ban' => $isGlobalBan,
+            'is_global_ban' => true,
             'expires_at' => $expiresAt,
         ]);
     }

--- a/repositories/GameBanRepository.php
+++ b/repositories/GameBanRepository.php
@@ -33,9 +33,20 @@ class GameBanRepository
 
     public function firstActiveBan(
         MinecraftPlayer $player,
+        bool $skipTempBans,
     ): ?GameBan {
         return GameBan::where('banned_player_id', $player->getKey())
             ->active()
+            ->when($skipTempBans, function ($q) {
+                $q->whereNull('expires_at');
+            })
             ->first();
+    }
+
+    public function deactivateAllTemporaryBans(MinecraftPlayer $player) {
+        GameBan::where('banned_player_id', $player->getKey())
+            ->active()
+            ->whereNotNull('expires_at')
+            ->update(['is_active' => false]);
     }
 }

--- a/repositories/GameBanRepository.php
+++ b/repositories/GameBanRepository.php
@@ -43,7 +43,8 @@ class GameBanRepository
             ->first();
     }
 
-    public function deactivateAllTemporaryBans(MinecraftPlayer $player) {
+    public function deactivateAllTemporaryBans(MinecraftPlayer $player)
+    {
         GameBan::where('banned_player_id', $player->getKey())
             ->active()
             ->whereNotNull('expires_at')

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\v1\MinecraftBalanceController;
 use App\Http\Controllers\Api\v1\MinecraftDonationTierController;
 use App\Http\Controllers\Api\v1\MinecraftTelemetryController;
 use App\Http\Controllers\Api\v2\GameBanV2Controller;
+use App\Http\Middleware\RequiresServerTokenScope;
 use Domain\ServerTokens\ScopeKey;
 use Illuminate\Support\Facades\Route;
 
@@ -20,14 +21,14 @@ use Illuminate\Support\Facades\Route;
 
 Route::prefix('bans')->group(function () {
     Route::middleware(
-        'server-token:'.ScopeKey::BAN_UPDATE->value,
+        RequiresServerTokenScope::middleware(ScopeKey::BAN_UPDATE),
     )->group(function () {
         Route::post('ban', [GameBanV2Controller::class, 'ban']);
         Route::post('unban', [GameBanV2Controller::class, 'unban']);
     });
 
     Route::middleware([
-        'server-token:'.ScopeKey::BAN_LOOKUP->value,
+        RequiresServerTokenScope::middleware(ScopeKey::BAN_LOOKUP),
     ])->group(function () {
         Route::post('status', [GameBanV2Controller::class, 'status']);
     });
@@ -37,20 +38,20 @@ Route::prefix('minecraft/{minecraftUUID}')->group(function () {
     Route::get('donation-tiers', [MinecraftDonationTierController::class, 'show']);
 
     Route::middleware(
-        'server-token:'.ScopeKey::ACCOUNT_BALANCE_SHOW->value
+        RequiresServerTokenScope::middleware(ScopeKey::ACCOUNT_BALANCE_SHOW),
     )->group(function () {
         Route::get('balance', [MinecraftBalanceController::class, 'show']);
     });
 
     Route::middleware(
-        'server-token:'.ScopeKey::ACCOUNT_BALANCE_DEDUCT->value
+        RequiresServerTokenScope::middleware(ScopeKey::ACCOUNT_BALANCE_DEDUCT),
     )->group(function () {
         Route::post('balance/deduct', [MinecraftBalanceController::class, 'deduct']);
     });
 });
 
 Route::middleware(
-    'server-token:'.ScopeKey::TELEMETRY->value
+    RequiresServerTokenScope::middleware(ScopeKey::TELEMETRY),
 )->group(function () {
     Route::prefix('minecraft/telemetry')->group(function () {
         Route::post('seen', [MinecraftTelemetryController::class, 'playerSeen']);

--- a/tests/E2E/API/APIBanCreateTest.php
+++ b/tests/E2E/API/APIBanCreateTest.php
@@ -2,9 +2,10 @@
 
 namespace Tests\E2E\API;
 
+use Carbon\Carbon;
 use Domain\ServerTokens\ScopeKey;
+use Entities\Models\Eloquent\GameBan;
 use Entities\Models\Eloquent\MinecraftPlayer;
-use Entities\Models\Eloquent\MinecraftPlayerAlias;
 use Entities\Models\PlayerIdentifierType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\E2ETestCase;
@@ -26,10 +27,11 @@ class APIBanCreateTest extends E2ETestCase
         return [
             'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
             'banned_player_id' => 'uuid1',
+            'banned_player_alias' => 'alias1',
             'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
             'banner_player_id' => 'uuid2',
+            'banner_player_alias' => 'alias2',
             'reason' => 'reason',
-            'expires_at' => null,
         ];
     }
 
@@ -37,57 +39,182 @@ class APIBanCreateTest extends E2ETestCase
     {
         $this->withAuthorizationServerToken()
             ->postJson(uri: self::ENDPOINT, data: $this->validData())
-            ->assertUnauthorized();
+            ->assertForbidden();
 
         $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
 
         $this->withAuthorizationServerToken()
             ->postJson(uri: self::ENDPOINT, data: $this->validData())
-            ->assertOk();
+            ->assertSuccessful();
     }
 
-    public function test_validates_input()
+    public function test_creates_permanent_ban()
     {
-        $this->authoriseTokenFor(ScopeKey::TELEMETRY);
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
 
         $this->withAuthorizationServerToken()
-            ->postJson(uri: self::ENDPOINT, data: ['alias' => 'alias'])
-            ->assertStatus(400);
-
-        $this->withAuthorizationServerToken()
-            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid'])
-            ->assertStatus(400);
-
-        $this->withAuthorizationServerToken()
-            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid', 'alias' => 'alias'])
-            ->assertOk();
-    }
-
-    public function test_updates_last_seen_date()
-    {
-        $player = MinecraftPlayer::factory()->create([
-            'uuid' => 'uuid',
-            'last_seen_at' => $this->now->copy()->subWeek(),
-        ]);
-
-        $this->authoriseTokenFor(ScopeKey::TELEMETRY);
-
-        $this->withAuthorizationServerToken()
-            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid', 'alias' => 'alias'])
-            ->assertOk();
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banned_player_alias' => 'alias1',
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+                'banner_player_alias' => 'alias2',
+                'reason' => 'reason',
+            ])
+            ->assertSuccessful();
 
         $this->assertDatabaseHas(
-            table: MinecraftPlayer::getTableName(),
+            table: GameBan::getTableName(),
             data: [
-                'player_minecraft_id' => $player->getKey(),
-                'uuid' => 'uuid',
-                'last_seen_at' => $this->now,
+                'server_id' => $this->token->server->getKey(),
+                'banned_player_id' => $player1->getKey(),
+                'banned_alias_at_time' => 'alias1',
+                'staff_player_id' => $player2->getKey(),
+                'reason' => 'reason',
+                'is_active' => true,
+                'is_global_ban' => true,
+                'expires_at' => null,
+                'created_at' => $this->now,
+                'updated_at' => $this->now,
             ],
         );
+    }
+
+    public function test_creates_temporary_ban()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $expiryDate = Carbon::now()->addMonth();
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banned_player_alias' => 'alias1',
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+                'banner_player_alias' => 'alias2',
+                'reason' => 'reason',
+                'expires_at' => $expiryDate->timestamp,
+            ])
+            ->assertSuccessful();
+
         $this->assertDatabaseHas(
-            table: MinecraftPlayerAlias::getTableName(),
+            table: GameBan::getTableName(),
             data: [
-                'alias' => 'alias',
+                'server_id' => $this->token->server->getKey(),
+                'banned_player_id' => $player1->getKey(),
+                'banned_alias_at_time' => 'alias1',
+                'staff_player_id' => $player2->getKey(),
+                'reason' => 'reason',
+                'is_active' => true,
+                'is_global_ban' => true,
+                'expires_at' => $expiryDate,
+                'created_at' => $this->now,
+                'updated_at' => $this->now,
+            ],
+        );
+    }
+
+    public function test_permanent_ban_fails_if_already_permanent_banned()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        GameBan::factory()
+            ->active()
+            ->bannedPlayer($player1)
+            ->create();
+
+        $this->assertDatabaseCount(table: GameBan::getTableName(), count: 1);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banned_player_alias' => 'alias1',
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+                'banner_player_alias' => 'alias2',
+                'reason' => 'reason',
+            ])
+            ->assertJson([
+                'error' => [
+                    'id' => 'player_already_banned',
+                    'title' => '',
+                    'detail' => 'Player is already banned',
+                    'status' => 400,
+                ],
+            ]);
+
+        $this->assertDatabaseCount(table: GameBan::getTableName(), count: 1);
+    }
+
+    public function test_create_permanent_ban_overrides_temporary_ban()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        $tempBan = GameBan::factory()
+            ->active()
+            ->temporary()
+            ->bannedPlayer($player1)
+            ->create();
+
+        $this->assertDatabaseHas(
+            table: GameBan::getTableName(),
+            data: [
+                'banned_player_id' => $player1->getKey(),
+                'is_active' => true,
+                'expires_at' => $tempBan->expires_at,
+            ],
+        );
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banned_player_alias' => 'alias1',
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+                'banner_player_alias' => 'alias2',
+                'reason' => 'reason',
+            ])
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas(
+            table: GameBan::getTableName(),
+            data: [
+                'banned_player_id' => $player1->getKey(),
+                'is_active' => false,
+                'expires_at' => $tempBan->expires_at,
+            ],
+        );
+
+        $this->assertDatabaseHas(
+            table: GameBan::getTableName(),
+            data: [
+                'server_id' => $this->token->server->getKey(),
+                'banned_player_id' => $player1->getKey(),
+                'banned_alias_at_time' => 'alias1',
+                'staff_player_id' => $player2->getKey(),
+                'reason' => 'reason',
+                'is_active' => true,
+                'is_global_ban' => true,
+                'expires_at' => null,
+                'created_at' => $this->now,
+                'updated_at' => $this->now,
             ],
         );
     }

--- a/tests/E2E/API/APIBanCreateTest.php
+++ b/tests/E2E/API/APIBanCreateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\E2E\API;
+
+use Domain\ServerTokens\ScopeKey;
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Models\Eloquent\MinecraftPlayerAlias;
+use Entities\Models\PlayerIdentifierType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\E2ETestCase;
+
+class APIBanCreateTest extends E2ETestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = 'api/v2/bans/ban';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerToken();
+    }
+
+    private function validData(): array {
+        return [
+            'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+            'banned_player_id' => 'uuid1',
+            'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+            'banner_player_id' => 'uuid2',
+            'reason' => 'reason',
+            'expires_at' => null,
+        ];
+    }
+
+    public function test_requires_scope()
+    {
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertUnauthorized();
+
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertOk();
+    }
+
+    public function test_validates_input()
+    {
+        $this->authoriseTokenFor(ScopeKey::TELEMETRY);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: ['alias' => 'alias'])
+            ->assertStatus(400);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid'])
+            ->assertStatus(400);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid', 'alias' => 'alias'])
+            ->assertOk();
+    }
+
+    public function test_updates_last_seen_date()
+    {
+        $player = MinecraftPlayer::factory()->create([
+            'uuid' => 'uuid',
+            'last_seen_at' => $this->now->copy()->subWeek(),
+        ]);
+
+        $this->authoriseTokenFor(ScopeKey::TELEMETRY);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid', 'alias' => 'alias'])
+            ->assertOk();
+
+        $this->assertDatabaseHas(
+            table: MinecraftPlayer::getTableName(),
+            data: [
+                'player_minecraft_id' => $player->getKey(),
+                'uuid' => 'uuid',
+                'last_seen_at' => $this->now,
+            ],
+        );
+        $this->assertDatabaseHas(
+            table: MinecraftPlayerAlias::getTableName(),
+            data: [
+                'alias' => 'alias',
+            ],
+        );
+    }
+}

--- a/tests/E2E/API/APIBanCreateTest.php
+++ b/tests/E2E/API/APIBanCreateTest.php
@@ -23,7 +23,8 @@ class APIBanCreateTest extends E2ETestCase
         $this->createServerToken();
     }
 
-    private function validData(): array {
+    private function validData(): array
+    {
         return [
             'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
             'banned_player_id' => 'uuid1',

--- a/tests/E2E/API/APIBanStatusTest.php
+++ b/tests/E2E/API/APIBanStatusTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\E2E\API;
+
+use Domain\ServerTokens\ScopeKey;
+use Entities\Models\Eloquent\GameBan;
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Models\Eloquent\Server;
+use Entities\Models\PlayerIdentifierType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\E2ETestCase;
+
+class APIBanStatusTest extends E2ETestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = 'api/v2/bans/status';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerToken();
+    }
+
+    private function validData(): array {
+        return [
+            'player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+            'player_id' => 'uuid1',
+        ];
+    }
+
+    public function test_requires_scope()
+    {
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertForbidden();
+
+        $this->authoriseTokenFor(ScopeKey::BAN_LOOKUP);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertSuccessful();
+    }
+
+    public function test_permanently_banned()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_LOOKUP);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+        $server = Server::factory()->hasCategory()->create();
+
+        $ban = GameBan::factory()
+            ->active()
+            ->bannedPlayer($player1)
+            ->bannedBy($player2)
+            ->server($server)
+            ->create();
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'player_id' => $player1->uuid,
+            ])
+            ->assertJson([
+                'data' => [
+                    'game_ban_id' => $ban->getKey(),
+                    'server_id' => $server->getKey(),
+                    'banned_player_id' => $player1->getKey(),
+                    'staff_player_id' => $player2->getKey(),
+                    'is_active' => true,
+                    'expires_at' => null,
+                ],
+            ])
+            ->assertSuccessful();
+    }
+
+    public function test_temporarily_banned()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_LOOKUP);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+        $server = Server::factory()->hasCategory()->create();
+
+        $ban = GameBan::factory()
+            ->active()
+            ->bannedPlayer($player1)
+            ->bannedBy($player2)
+            ->server($server)
+            ->temporary()
+            ->create();
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'player_id' => $player1->uuid,
+            ])
+            ->assertJson([
+                'data' => [
+                    'game_ban_id' => $ban->getKey(),
+                    'server_id' => $server->getKey(),
+                    'banned_player_id' => $player1->getKey(),
+                    'staff_player_id' => $player2->getKey(),
+                    'is_active' => true,
+                    'expires_at' => $ban->expires_at->timestamp,
+                ],
+            ])
+            ->assertSuccessful();
+    }
+
+    public function test_not_banned()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_LOOKUP);
+
+        $player = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'player_id' => $player->uuid,
+            ])
+            ->assertJson([
+                'data' => [],
+            ])
+            ->assertSuccessful();
+    }
+}

--- a/tests/E2E/API/APIBanStatusTest.php
+++ b/tests/E2E/API/APIBanStatusTest.php
@@ -23,7 +23,8 @@ class APIBanStatusTest extends E2ETestCase
         $this->createServerToken();
     }
 
-    private function validData(): array {
+    private function validData(): array
+    {
         return [
             'player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
             'player_id' => 'uuid1',

--- a/tests/E2E/API/APIMinecraftBalanceDeductTest.php
+++ b/tests/E2E/API/APIMinecraftBalanceDeductTest.php
@@ -36,7 +36,7 @@ class APIMinecraftBalanceDeductTest extends E2ETestCase
 
         $this->withAuthorizationServerToken()
             ->postJson($this->endpoint($player))
-            ->assertUnauthorized();
+            ->assertForbidden();
 
         $this->authoriseTokenFor(ScopeKey::ACCOUNT_BALANCE_DEDUCT);
 

--- a/tests/E2E/API/APIMinecraftBalanceShowTest.php
+++ b/tests/E2E/API/APIMinecraftBalanceShowTest.php
@@ -35,7 +35,7 @@ class APIMinecraftBalanceShowTest extends E2ETestCase
 
         $this->withAuthorizationServerToken()
             ->getJson($this->endpoint($player))
-            ->assertUnauthorized();
+            ->assertForbidden();
 
         $this->authoriseTokenFor(ScopeKey::ACCOUNT_BALANCE_SHOW);
 

--- a/tests/E2E/API/APIMinecraftTelemetryTest.php
+++ b/tests/E2E/API/APIMinecraftTelemetryTest.php
@@ -25,7 +25,7 @@ class APIMinecraftTelemetryTest extends E2ETestCase
     {
         $this->withAuthorizationServerToken()
             ->postJson(uri: self::ENDPOINT, data: ['uuid' => 'uuid', 'alias' => 'alias'])
-            ->assertUnauthorized();
+            ->assertForbidden();
 
         $this->authoriseTokenFor(ScopeKey::TELEMETRY);
 

--- a/tests/E2E/API/APIUnbanCreateTest.php
+++ b/tests/E2E/API/APIUnbanCreateTest.php
@@ -23,7 +23,8 @@ class APIUnbanCreateTest extends E2ETestCase
         $this->createServerToken();
     }
 
-    private function validData(): array {
+    private function validData(): array
+    {
         return [
             'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
             'banned_player_id' => 'uuid1',

--- a/tests/E2E/API/APIUnbanCreateTest.php
+++ b/tests/E2E/API/APIUnbanCreateTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\E2E\API;
 
-use Carbon\Carbon;
 use Domain\ServerTokens\ScopeKey;
 use Entities\Models\Eloquent\GameBan;
 use Entities\Models\Eloquent\GameUnban;

--- a/tests/E2E/API/APIUnbanCreateTest.php
+++ b/tests/E2E/API/APIUnbanCreateTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\E2E\API;
+
+use Carbon\Carbon;
+use Domain\ServerTokens\ScopeKey;
+use Entities\Models\Eloquent\GameBan;
+use Entities\Models\Eloquent\GameUnban;
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Entities\Models\PlayerIdentifierType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\E2ETestCase;
+
+class APIUnbanCreateTest extends E2ETestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = 'api/v2/bans/unban';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerToken();
+    }
+
+    private function validData(): array {
+        return [
+            'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+            'banned_player_id' => 'uuid1',
+            'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+            'banner_player_id' => 'uuid2',
+        ];
+    }
+
+    public function test_requires_scope()
+    {
+        GameBan::factory()
+            ->active()
+            ->bannedPlayer(MinecraftPlayer::factory()->create(['uuid' => 'uuid1']))
+            ->create();
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertForbidden();
+
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: $this->validData())
+            ->assertSuccessful();
+    }
+
+    public function test_throws_exception_if_not_banned()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+                'reason' => 'reason',
+            ])
+            ->assertJson([
+                'error' => [
+                    'id' => 'player_not_banned',
+                    'title' => '',
+                    'detail' => 'This player is not currently banned',
+                    'status' => 400,
+                ],
+            ]);
+    }
+
+    public function test_unbans_permanent_ban()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        $ban = GameBan::factory()
+            ->active()
+            ->bannedPlayer($player1)
+            ->create();
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+            ])
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas(
+            table: GameBan::getTableName(),
+            data: [
+                'game_ban_id' => $ban->getKey(),
+                'is_active' => false,
+            ],
+        );
+
+        $this->assertDatabaseHas(
+            table: GameUnban::getTableName(),
+            data: [
+                'staff_player_id' => $player2->getKey(),
+            ],
+        );
+    }
+
+    public function test_unbans_temporary_ban()
+    {
+        $this->authoriseTokenFor(ScopeKey::BAN_UPDATE);
+
+        $player1 = MinecraftPlayer::factory()->create(['uuid' => 'uuid1']);
+        $player2 = MinecraftPlayer::factory()->create(['uuid' => 'uuid2']);
+
+        $ban = GameBan::factory()
+            ->active()
+            ->temporary()
+            ->bannedPlayer($player1)
+            ->create();
+
+        $this->withAuthorizationServerToken()
+            ->postJson(uri: self::ENDPOINT, data: [
+                'banned_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banned_player_id' => $player1->uuid,
+                'banner_player_type' => PlayerIdentifierType::MINECRAFT_UUID->value,
+                'banner_player_id' => $player2->uuid,
+            ])
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas(
+            table: GameBan::getTableName(),
+            data: [
+                'game_ban_id' => $ban->getKey(),
+                'is_active' => false,
+            ],
+        );
+
+        $this->assertDatabaseHas(
+            table: GameUnban::getTableName(),
+            data: [
+                'staff_player_id' => $player2->getKey(),
+            ],
+        );
+    }
+}

--- a/tests/Feature/RequiresServerTokenScopeTest.php
+++ b/tests/Feature/RequiresServerTokenScopeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\RequiresServerTokenScope;
+use Domain\ServerTokens\ScopeKey;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\E2ETestCase;
+
+class RequiresServerTokenScopeTest extends E2ETestCase
+{
+    public function test_throws_unauthorized_exception_if_token_missing()
+    {
+        try {
+            $middleware = new RequiresServerTokenScope();
+            $middleware->handle(
+                request: Request::create(uri: 'test'),
+                next: function() {},
+                scope: ScopeKey::BAN_LOOKUP->value,
+            );
+        }
+        catch (HttpException $e) {}
+
+        $this->assertEquals(
+            expected: new HttpException(401),
+            actual: $e,
+        );
+    }
+
+    public function test_throws_unauthorized_exception_if_token_malformed()
+    {
+        $invalidTokens = ['invalid', 'Bearer'];
+
+        foreach ($invalidTokens as $invalidToken) {
+            $request = Request::create(uri: 'test');
+            $request->headers->set(key: 'Authorization', values: $invalidToken);
+
+            try {
+                $middleware = new RequiresServerTokenScope();
+                $middleware->handle(
+                    request: $request,
+                    next: function() {},
+                    scope: ScopeKey::BAN_LOOKUP->value,
+                );
+            }
+            catch (HttpException $e) {}
+
+            $this->assertEquals(
+                expected: new HttpException(401),
+                actual: $e,
+            );
+            $this->assertEquals(
+                expected: $invalidToken,
+                actual: $request->headers->get('Authorization'),
+            );
+        }
+    }
+
+    public function test_throws_unauthorized_exception_if_token_not_registered()
+    {
+        $request = Request::create(uri: 'test');
+        $request->headers->set(key: 'Authorization', values: 'Bearer some_token');
+
+        try {
+            $middleware = new RequiresServerTokenScope();
+            $middleware->handle(
+                request: $request,
+                next: function () {},
+                scope: ScopeKey::BAN_LOOKUP->value,
+            );
+        }
+        catch (HttpException $e) {}
+
+        $this->assertEquals(
+            expected: new HttpException(401),
+            actual: $e,
+        );
+        $this->assertEquals(
+            expected: 'Bearer some_token',
+            actual: $request->headers->get('Authorization'),
+        );
+    }
+
+    public function test_throws_forbidden_exception_if_scope_not_allowed_by_key()
+    {
+        $token = $this->createServerToken();
+
+        $request = Request::create(uri: 'test');
+        $request->headers->set(key: 'Authorization', values: 'Bearer '.$token->token);
+
+        try {
+            $middleware = new RequiresServerTokenScope();
+            $middleware->handle(
+                request: $request,
+                next: function () {},
+                scope: ScopeKey::BAN_LOOKUP->value,
+            );
+        } catch (HttpException $e) {
+        }
+
+        $this->assertEquals(
+            expected: new HttpException(403),
+            actual: $e,
+        );
+        $this->assertEquals(
+            expected: 'Bearer '.$token->token,
+            actual: $request->headers->get('Authorization'),
+        );
+    }
+
+    public function test_valid_token_passes_onto_next_middleware()
+    {
+        $token = $this->createServerToken();
+        $this->authoriseTokenFor(ScopeKey::BAN_LOOKUP);
+
+        $request = Request::create(uri: 'test');
+        $request->headers->set(key: 'Authorization', values: 'Bearer '.$token->token);
+
+        $didPass = false;
+        $middleware = new RequiresServerTokenScope();
+        $middleware->handle(
+            request: $request,
+            next: function () use (&$didPass) {
+                $didPass = true;
+            },
+            scope: ScopeKey::BAN_LOOKUP->value,
+        );
+
+        $this->assertTrue($didPass);
+        $this->assertEquals(
+            expected: 'Bearer '.$token->token,
+            actual: $request->headers->get('Authorization'),
+        );
+        $this->assertEquals(
+            expected: $token->getKey(),
+            actual: $request->token->getKey(),
+        );
+    }
+}

--- a/tests/Feature/RequiresServerTokenScopeTest.php
+++ b/tests/Feature/RequiresServerTokenScopeTest.php
@@ -16,11 +16,12 @@ class RequiresServerTokenScopeTest extends E2ETestCase
             $middleware = new RequiresServerTokenScope();
             $middleware->handle(
                 request: Request::create(uri: 'test'),
-                next: function() {},
+                next: function () {
+                },
                 scope: ScopeKey::BAN_LOOKUP->value,
             );
+        } catch (HttpException $e) {
         }
-        catch (HttpException $e) {}
 
         $this->assertEquals(
             expected: new HttpException(401),
@@ -40,11 +41,12 @@ class RequiresServerTokenScopeTest extends E2ETestCase
                 $middleware = new RequiresServerTokenScope();
                 $middleware->handle(
                     request: $request,
-                    next: function() {},
+                    next: function () {
+                    },
                     scope: ScopeKey::BAN_LOOKUP->value,
                 );
+            } catch (HttpException $e) {
             }
-            catch (HttpException $e) {}
 
             $this->assertEquals(
                 expected: new HttpException(401),
@@ -66,11 +68,12 @@ class RequiresServerTokenScopeTest extends E2ETestCase
             $middleware = new RequiresServerTokenScope();
             $middleware->handle(
                 request: $request,
-                next: function () {},
+                next: function () {
+                },
                 scope: ScopeKey::BAN_LOOKUP->value,
             );
+        } catch (HttpException $e) {
         }
-        catch (HttpException $e) {}
 
         $this->assertEquals(
             expected: new HttpException(401),
@@ -93,7 +96,8 @@ class RequiresServerTokenScopeTest extends E2ETestCase
             $middleware = new RequiresServerTokenScope();
             $middleware->handle(
                 request: $request,
-                next: function () {},
+                next: function () {
+                },
                 scope: ScopeKey::BAN_LOOKUP->value,
             );
         } catch (HttpException $e) {

--- a/tests/Feature/TelescopeAccessTest.php
+++ b/tests/Feature/TelescopeAccessTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Test\Feature;
+namespace Tests\Feature;
 
 use Entities\Models\PanelGroupScope;
 use Illuminate\Support\Facades\Config;

--- a/tests/Unit/Domain/Bans/UseCases/CreateBanUseCaseTest.php
+++ b/tests/Unit/Domain/Bans/UseCases/CreateBanUseCaseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\Domain\Bans\UseCases;
+
+use Domain\Bans\Exceptions\PlayerAlreadyBannedException;
+use Domain\Bans\UseCases\CreateBanUseCase;
+use Entities\Models\Eloquent\GameBan;
+use Entities\Models\Eloquent\MinecraftPlayer;
+use Repositories\GameBanRepository;
+use Shared\PlayerLookup\Entities\PlayerIdentifier;
+use Shared\PlayerLookup\PlayerLookup;
+use Tests\TestCase;
+
+class CreateBanUseCaseTest extends TestCase
+{
+    private readonly PlayerLookup $playerLookup;
+    private readonly GameBanRepository $gameBanRepository;
+    private readonly CreateBanUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gameBanRepository = \Mockery::mock(GameBanRepository::class);
+        $this->playerLookup = \Mockery::mock(PlayerLookup::class);
+
+        $this->useCase = new CreateBanUseCase(
+            gameBanRepository: $this->gameBanRepository,
+            playerLookup: $this->playerLookup,
+        );
+    }
+
+    public function test_throws_exception_if_already_banned()
+    {
+        $this->playerLookup
+            ->shouldReceive('findOrCreate')
+            ->andReturn(MinecraftPlayer::factory()->make());
+
+        $this->gameBanRepository
+            ->shouldReceive('firstActiveBan')
+            ->andReturn(GameBan::factory()->make());
+
+        $this->expectException(PlayerAlreadyBannedException::class);
+
+        $this->useCase->execute(
+            serverId: 1,
+            bannedPlayerIdentifier: PlayerIdentifier::minecraftUUID('uuid1'),
+            bannedPlayerAlias: 'Herobrine',
+            bannerPlayerIdentifier: PlayerIdentifier::minecraftUUID('uuid2'),
+            bannerPlayerAlias: 'Notch',
+            banReason: 'test',
+            expiresAt: null,
+        );
+    }
+
+    public function test_creates_ban()
+    {
+        $bannedPlayer = MinecraftPlayer::factory()->create();
+        $bannerPlayer = MinecraftPlayer::factory()->create();
+        $ban = GameBan::factory()->make();
+
+        $this->playerLookup
+            ->shouldReceive('findOrCreate')
+            ->andReturn($bannedPlayer);
+
+        $this->playerLookup
+            ->shouldReceive('findOrCreate')
+            ->andReturn($bannerPlayer);
+
+        $this->gameBanRepository
+            ->shouldReceive('firstActiveBan')
+            ->andReturn(null);
+
+        $this->gameBanRepository
+            ->shouldReceive('create')
+            ->andReturn($ban);
+
+        $returnedBan = $this->useCase->execute(
+            serverId: 1,
+            bannedPlayerIdentifier: PlayerIdentifier::minecraftUUID('uuid1'),
+            bannedPlayerAlias: 'Herobrine',
+            bannerPlayerIdentifier: PlayerIdentifier::minecraftUUID('uuid2'),
+            bannerPlayerAlias: 'Notch',
+            banReason: 'test',
+            expiresAt: null,
+        );
+
+        $this->assertEquals(expected: $ban, actual: $returnedBan);
+    }
+}

--- a/tests/Unit/Domain/Bans/UseCases/CreateBanUseCaseTest.php
+++ b/tests/Unit/Domain/Bans/UseCases/CreateBanUseCaseTest.php
@@ -75,6 +75,9 @@ class CreateBanUseCaseTest extends TestCase
             ->shouldReceive('create')
             ->andReturn($ban);
 
+        $this->gameBanRepository
+            ->shouldReceive('deactivateAllTemporaryBans');
+
         $returnedBan = $this->useCase->execute(
             serverId: 1,
             bannedPlayerIdentifier: PlayerIdentifier::minecraftUUID('uuid1'),

--- a/tests/Unit/Domain/Bans/UseCases/LookupBanUseCaseTest.php
+++ b/tests/Unit/Domain/Bans/UseCases/LookupBanUseCaseTest.php
@@ -37,7 +37,8 @@ class LookupBanUseCaseTest extends TestCase
 
     private function mockMojangApiToReturn($username, $uuid)
     {
-        $this->mojangPlayerApi->shouldReceive('getUuidOf')
+        $this->mojangPlayerApi
+            ->shouldReceive('getUuidOf')
             ->once()
             ->with($username)
             ->once()->andReturn(
@@ -47,7 +48,8 @@ class LookupBanUseCaseTest extends TestCase
 
     private function mockPlayerRepositoryToReturn($uuid, $player)
     {
-        $this->minecraftPlayerRepository->shouldReceive('getByUUID')
+        $this->minecraftPlayerRepository
+            ->shouldReceive('getByUUID')
             ->once()
             ->with(\Mockery::on(function ($arg) use ($uuid) {
                 return $arg->rawValue() == $uuid;
@@ -57,11 +59,15 @@ class LookupBanUseCaseTest extends TestCase
 
     public function mockGameBanRepositoryToReturn($playerId, $bans)
     {
-        $this->gameBanRepository->shouldReceive('firstActiveBan')
+        $this->gameBanRepository
+            ->shouldReceive('firstActiveBan')
             ->once()
-            ->with(\Mockery::on(function ($arg) use ($playerId) {
-                return $arg->getKey() == $playerId;
-            }))
+            ->with(
+                \Mockery::on(function ($arg) use ($playerId) {
+                    return $arg->getKey() == $playerId;
+                }),
+                \Mockery::on(fn () => true),
+            )
             ->andReturn($bans);
     }
 

--- a/tests/Unit/Domain/Bans/UseCases/LookupBanUseCaseTest.php
+++ b/tests/Unit/Domain/Bans/UseCases/LookupBanUseCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Unit\Domain\Bans\UseCases;
+namespace Tests\Unit\Domain\Bans\UseCases;
 
 use Domain\Bans\Exceptions\PlayerNotBannedException;
 use Domain\Bans\UseCases\LookupBanUseCase;


### PR DESCRIPTION
## Overview of Changes

Brings Ban API v2 up to feature parity with v1.
Adds E2E tests to cover all ban API endpoints.

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
