### PR TITLE
Aggregate Minecraft endpoint

### DIFF
--- a/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
@@ -2,16 +2,13 @@
 
 namespace App\Http\Controllers\Api\v1;
 
-use App\Exceptions\Http\BadRequestException;
 use App\Exceptions\Http\NotFoundException;
-use App\Exceptions\Http\UnauthorisedException;
 use App\Http\ApiController;
 use Domain\Badges\UseCases\GetBadgesUseCase;
 use Domain\Bans\UseCases\GetBanUseCase;
 use Domain\Donations\UseCases\GetDonationTiersUseCase;
 use Entities\Models\Eloquent\Account;
 use Entities\Models\Eloquent\MinecraftPlayer;
-use Entities\Models\PlayerIdentifierType;
 use Entities\Resources\AccountResource;
 use Entities\Resources\DonationPerkResource;
 use Entities\Resources\GameBanResource;

--- a/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Exceptions\Http\NotFoundException;
+use App\Http\ApiController;
+use Domain\Badges\UseCases\GetBadgesUseCase;
+use Domain\Bans\UseCases\GetBanUseCase;
+use Domain\Donations\UseCases\GetDonationTiersUseCase;
+use Entities\Models\PlayerIdentifierType;
+use Entities\Resources\DonationPerkResource;
+use Entities\Resources\GameBanResource;
+use Illuminate\Http\Request;
+use Shared\PlayerLookup\Entities\PlayerIdentifier;
+
+final class MinecraftAggregateController extends ApiController
+{
+    public function show(
+        Request $request,
+        string $uuid,
+        GetBanUseCase $getBan,
+        GetBadgesUseCase $getBadges,
+        GetDonationTiersUseCase $getDonationTier,
+    ) {
+        $identifier = PlayerIdentifier::minecraftUUID($uuid);
+
+        $ban = $getBan->execute(playerIdentifier: $identifier);
+        $badges = $getBadges->execute(identifier: $identifier);
+
+        try {
+            $donationTiers = $getDonationTier->execute(uuid: $uuid);
+        } catch (NotFoundException) {
+            $donationTiers = [];
+        }
+
+        return [
+            'data' => [
+                'ban' => is_null($ban) ? null : new GameBanResource($ban),
+                'badges' => $badges,
+                'donation_tiers' => DonationPerkResource::collection($donationTiers),
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftAggregateController.php
@@ -2,12 +2,17 @@
 
 namespace App\Http\Controllers\Api\v1;
 
+use App\Exceptions\Http\BadRequestException;
 use App\Exceptions\Http\NotFoundException;
+use App\Exceptions\Http\UnauthorisedException;
 use App\Http\ApiController;
 use Domain\Badges\UseCases\GetBadgesUseCase;
 use Domain\Bans\UseCases\GetBanUseCase;
 use Domain\Donations\UseCases\GetDonationTiersUseCase;
+use Entities\Models\Eloquent\Account;
+use Entities\Models\Eloquent\MinecraftPlayer;
 use Entities\Models\PlayerIdentifierType;
+use Entities\Resources\AccountResource;
 use Entities\Resources\DonationPerkResource;
 use Entities\Resources\GameBanResource;
 use Illuminate\Http\Request;
@@ -33,12 +38,30 @@ final class MinecraftAggregateController extends ApiController
             $donationTiers = [];
         }
 
+        $account = $this->getLinkedAccount($uuid);
+
         return [
             'data' => [
+                'account' => is_null($account) ? null : new AccountResource($account),
                 'ban' => is_null($ban) ? null : new GameBanResource($ban),
                 'badges' => $badges,
                 'donation_tiers' => DonationPerkResource::collection($donationTiers),
             ],
         ];
+    }
+
+    // TODO: share this logic with MinecraftAuthTokenController
+    private function getLinkedAccount(string $uuid): ?Account
+    {
+        $existingPlayer = MinecraftPlayer::where('uuid', $uuid)->first();
+
+        if ($existingPlayer === null || $existingPlayer->account === null) {
+            return null;
+        }
+        // Force load groups
+        $existingPlayer->account->groups;
+        $existingPlayer->touchLastSyncedAt();
+
+        return $existingPlayer->account;
     }
 }

--- a/app/Http/Controllers/Api/v1/MinecraftBadgeController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftBadgeController.php
@@ -3,36 +3,20 @@
 namespace App\Http\Controllers\Api\v1;
 
 use App\Http\ApiController;
-use Entities\Models\Eloquent\Badge;
+use Domain\Badges\UseCases\GetBadgesUseCase;
 use Illuminate\Http\Request;
 use Shared\PlayerLookup\Entities\PlayerIdentifier;
-use Shared\PlayerLookup\PlayerLookup;
 
 final class MinecraftBadgeController extends ApiController
 {
     public function show(
         Request $request,
         string $uuid,
-        PlayerLookup $playerLookup,
+        GetBadgesUseCase $getBadges,
     ) {
-        $account = $playerLookup
-            ->find(identifier: PlayerIdentifier::minecraftUUID($uuid))
-            ?->getLinkedAccount();
-
-        if ($account === null) {
-            return ['data' => []];
-        }
-
-        $badges = $account->badges;
-        $accountAgeInYears = $account->created_at->diffInYears(now());
-
-        if ($accountAgeInYears >= 3) {
-            $badge = new Badge();
-            $badge->display_name = $accountAgeInYears.' years on PCB';
-            $badge->unicode_icon = '⌚';
-            $badges->add($badge);
-        }
-
+        $badges = $getBadges->execute(
+            identifier: PlayerIdentifier::minecraftUUID($uuid)
+        );
         return [
             'data' => $badges,
         ];

--- a/app/Http/Controllers/Api/v1/MinecraftBadgeController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftBadgeController.php
@@ -17,6 +17,7 @@ final class MinecraftBadgeController extends ApiController
         $badges = $getBadges->execute(
             identifier: PlayerIdentifier::minecraftUUID($uuid)
         );
+
         return [
             'data' => $badges,
         ];

--- a/app/Http/Controllers/Api/v1/MinecraftDonationTierController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftDonationTierController.php
@@ -10,8 +10,8 @@ use Illuminate\Http\Request;
 final class MinecraftDonationTierController extends ApiController
 {
     public function show(
-        Request                 $request,
-        string                  $uuid,
+        Request $request,
+        string $uuid,
         GetDonationTiersUseCase $getDonationTier,
     ) {
         $uuid = str_replace(search: '-', replace: '', subject: $uuid);

--- a/app/Http/Controllers/Api/v1/MinecraftDonationTierController.php
+++ b/app/Http/Controllers/Api/v1/MinecraftDonationTierController.php
@@ -2,40 +2,22 @@
 
 namespace App\Http\Controllers\Api\v1;
 
-use App\Exceptions\Http\NotFoundException;
 use App\Http\ApiController;
-use Entities\Models\Eloquent\MinecraftPlayer;
+use Domain\Donations\UseCases\GetDonationTiersUseCase;
 use Entities\Resources\DonationPerkResource;
 use Illuminate\Http\Request;
 
 final class MinecraftDonationTierController extends ApiController
 {
-    public function show(Request $request, string $uuid)
-    {
-        $uuid = str_replace('-', '', $uuid);
+    public function show(
+        Request                 $request,
+        string                  $uuid,
+        GetDonationTiersUseCase $getDonationTier,
+    ) {
+        $uuid = str_replace(search: '-', replace: '', subject: $uuid);
 
-        $existingPlayer = MinecraftPlayer::where('uuid', $uuid)
-            ->with('account.donationPerks.donationTier')
-            ->first();
-
-        if ($existingPlayer === null) {
-            throw new NotFoundException('player_not_found', 'Minecraft player not found for given UUID');
-        }
-
-        $account = $existingPlayer->account;
-        if ($account === null) {
-            throw new NotFoundException('player_not_linked', 'Minecraft player not linked to an account');
-        }
-
-        $perks = $account->donationPerks
-            ->where('is_active', true)
-            ->where('expires_at', '>', now())
-            ->unique('donation_tier_id');
-
-        if ($perks === null || count($perks) === 0) {
-            return ['data' => null]; // No donation perks for this account
-        }
-
-        return DonationPerkResource::collection($perks);
+        return DonationPerkResource::collection(
+            $getDonationTier->execute(uuid: $uuid)
+        );
     }
 }

--- a/domain/Badges/UseCases/GetBadgesUseCase.php
+++ b/domain/Badges/UseCases/GetBadgesUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Domain\Badges\UseCases;
+
+use Entities\Models\Eloquent\Badge;
+use Shared\PlayerLookup\Entities\PlayerIdentifier;
+use Shared\PlayerLookup\PlayerLookup;
+
+final class GetBadgesUseCase
+{
+    public function __construct(
+        private readonly PlayerLookup $playerLookup,
+    ) {}
+
+    public function execute(PlayerIdentifier $identifier): array
+    {
+        $account = $this->playerLookup
+            ->find(identifier: $identifier)
+            ?->getLinkedAccount();
+
+        if ($account === null) {
+            return [];
+        }
+
+        $badges = $account->badges;
+        $accountAgeInYears = $account->created_at->diffInYears(now());
+
+        if ($accountAgeInYears >= 3) {
+            $badge = new Badge();
+            $badge->display_name = $accountAgeInYears.' years on PCB';
+            $badge->unicode_icon = '⌚';
+            $badges->add($badge);
+        }
+
+        return $badges->toArray();
+    }
+}

--- a/domain/Badges/UseCases/GetBadgesUseCase.php
+++ b/domain/Badges/UseCases/GetBadgesUseCase.php
@@ -10,7 +10,8 @@ final class GetBadgesUseCase
 {
     public function __construct(
         private readonly PlayerLookup $playerLookup,
-    ) {}
+    ) {
+    }
 
     public function execute(PlayerIdentifier $identifier): array
     {

--- a/domain/Donations/UseCases/GetDonationTiersUseCase.php
+++ b/domain/Donations/UseCases/GetDonationTiersUseCase.php
@@ -4,13 +4,14 @@ namespace Domain\Donations\UseCases;
 
 use App\Exceptions\Http\NotFoundException;
 use Entities\Models\Eloquent\MinecraftPlayer;
+use Illuminate\Support\Collection;
 
 final class GetDonationTiersUseCase
 {
     /**
      * @throws NotFoundException if player not found or not linked to an account
      */
-    public function execute(string $uuid): array
+    public function execute(string $uuid): Collection
     {
         $existingPlayer = MinecraftPlayer::where('uuid', $uuid)
             ->with('account.donationPerks.donationTier')
@@ -31,9 +32,9 @@ final class GetDonationTiersUseCase
             ->unique('donation_tier_id');
 
         if ($perks === null || count($perks) === 0) {
-            return []; // No donation perks for this account
+            return collect(); // No donation perks for this account
         }
 
-        return $perks->toArray();
+        return $perks;
     }
 }

--- a/domain/Donations/UseCases/GetDonationTiersUseCase.php
+++ b/domain/Donations/UseCases/GetDonationTiersUseCase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Domain\Donations\UseCases;
+
+use App\Exceptions\Http\NotFoundException;
+use Entities\Models\Eloquent\MinecraftPlayer;
+
+final class GetDonationTiersUseCase
+{
+    /**
+     * @throws NotFoundException if player not found or not linked to an account
+     */
+    public function execute(string $uuid): array
+    {
+        $existingPlayer = MinecraftPlayer::where('uuid', $uuid)
+            ->with('account.donationPerks.donationTier')
+            ->first();
+
+        if ($existingPlayer === null) {
+            throw new NotFoundException('player_not_found', 'Minecraft player not found for given UUID');
+        }
+
+        $account = $existingPlayer->account;
+        if ($account === null) {
+            throw new NotFoundException('player_not_linked', 'Minecraft player not linked to an account');
+        }
+
+        $perks = $account->donationPerks
+            ->where('is_active', true)
+            ->where('expires_at', '>', now())
+            ->unique('donation_tier_id');
+
+        if ($perks === null || count($perks) === 0) {
+            return []; // No donation perks for this account
+        }
+        return $perks->toArray();
+    }
+}

--- a/domain/Donations/UseCases/GetDonationTiersUseCase.php
+++ b/domain/Donations/UseCases/GetDonationTiersUseCase.php
@@ -33,6 +33,7 @@ final class GetDonationTiersUseCase
         if ($perks === null || count($perks) === 0) {
             return []; // No donation perks for this account
         }
+
         return $perks->toArray();
     }
 }

--- a/entities/Resources/AccountResource.php
+++ b/entities/Resources/AccountResource.php
@@ -16,7 +16,6 @@ final class AccountResource extends JsonResource
     {
         return [
             'account_id' => $this->account_id,
-            'email' => $this->email,
             'username' => $this->username,
             'last_login_at' => $this->last_login_at,
             'created_at' => $this->created_at->getTimestamp(),

--- a/routes/api_v2.php
+++ b/routes/api_v2.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\v1\MinecraftAggregateController;
 use App\Http\Controllers\Api\v1\MinecraftBadgeController;
 use App\Http\Controllers\Api\v1\MinecraftBalanceController;
 use App\Http\Controllers\Api\v1\MinecraftDonationTierController;
@@ -38,6 +39,7 @@ Route::prefix('bans')->group(function () {
 Route::prefix('minecraft/{minecraftUUID}')->group(function () {
     Route::get('donation-tiers', [MinecraftDonationTierController::class, 'show']);
     Route::get('badges', [MinecraftBadgeController::class, 'show']);
+    Route::get('aggregate', [MinecraftAggregateController::class, 'show']);
 
     Route::middleware(
         RequiresServerTokenScope::middleware(ScopeKey::ACCOUNT_BALANCE_SHOW),


### PR DESCRIPTION
## Overview of Changes

Adds a single endpoint that fetches all the required Minecraft player data for when a player connects to the server.

This will help simplify PCBridge as it's currently making several concurrent calls to fetch all this data at different timings.

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
