### PR TITLE
Create command to fix account creation dates

### DIFF
--- a/app/Console/Commands/AccountCreatedAtImport.php
+++ b/app/Console/Commands/AccountCreatedAtImport.php
@@ -42,5 +42,7 @@ class AccountCreatedAtImport extends Command
             $user->created_at = Carbon::parse($entry['created_at']);
             $user->disableLogging()->save();
         });
+
+        return 0;
     }
 }

--- a/app/Console/Commands/AccountCreatedAtImport.php
+++ b/app/Console/Commands/AccountCreatedAtImport.php
@@ -38,9 +38,14 @@ class AccountCreatedAtImport extends Command
     {
         $entries = $this->getDataFileContents();
         $this->withProgressBar($entries, function ($entry) {
-            $user = Account::findOrFail($entry['external_id']);
-            $user->created_at = Carbon::parse($entry['created_at']);
-            $user->disableLogging()->save();
+            $user = Account::find($entry['external_id']);
+
+            if ($user == null) {
+                $this->info("Skipping #{$entry["external_id"]}");
+            } else {
+                $user->created_at = Carbon::parse($entry['created_at']);
+                $user->disableLogging()->save();
+            }
         });
 
         return 0;

--- a/app/Console/Commands/AccountCreatedAtImport.php
+++ b/app/Console/Commands/AccountCreatedAtImport.php
@@ -41,7 +41,7 @@ class AccountCreatedAtImport extends Command
             $user = Account::find($entry['external_id']);
 
             if ($user == null) {
-                $this->info("Skipping #{$entry["external_id"]}");
+                $this->info("Skipping #{$entry['external_id']}");
             } else {
                 $user->created_at = Carbon::parse($entry['created_at']);
                 $user->disableLogging()->save();

--- a/app/Console/Commands/AccountCreatedAtImport.php
+++ b/app/Console/Commands/AccountCreatedAtImport.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use Entities\Models\Eloquent\Account;
+use Illuminate\Console\Command;
+
+class AccountCreatedAtImport extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'one-off:createdatimport';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import created at dates';
+
+    private function getDataFileContents()
+    {
+        $data = file_get_contents(storage_path('app/id_created_at.json'));
+
+        return json_decode($data, associative: true);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $entries = $this->getDataFileContents();
+        $this->withProgressBar($entries, function ($entry) {
+            $user = Account::findOrFail($entry['external_id']);
+            $user->created_at = Carbon::parse($entry['created_at']);
+            $user->disableLogging()->save();
+        });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\AccountCreatedAtImport;
 use App\Console\Commands\CleanupUnactivatedAccountsCommand;
 use App\Console\Commands\DeactivateDonatorPerksCommand;
 use App\Console\Commands\DeleteExpiredPasswordResetsCommand;
@@ -32,6 +33,7 @@ class Kernel extends ConsoleKernel
         ServerKeyCreateCommand::class,
         ServerQueryCommand::class,
         StripUUIDHyphensCommand::class,
+        AccountCreatedAtImport::class,
     ];
 
     /**


### PR DESCRIPTION
## Overview of Changes
* Adds a one-off command to import created at times from discourse

I probably should make it bulk update properly, but since it's a one-off command and it's not doing that many records, probably not worth it.

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [x] Other (please specify)
  - The data file must be placed in `storage/app/id_created_at.json`