### PR TITLE
Queue notifications

### DIFF
--- a/app/Console/Commands/ServerQueryCommand.php
+++ b/app/Console/Commands/ServerQueryCommand.php
@@ -69,7 +69,7 @@ final class ServerQueryCommand extends Command
     {
         if ($shouldRunInBackground) {
             $this->info('Starting server query on background queue ['.$server->address().']');
-            ServerQueryJob::dispatch($server);
+            ServerQueryJob::dispatch($server)->onQueue('server-status');
 
             return;
         }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -46,12 +46,11 @@ class Kernel extends ConsoleKernel
         $schedule->command('telescope:prune')
             ->daily();
 
-        if (Environment::isLocalDev()) {
-            return;
-        }
-
-        $schedule->command('server:query --all')
+        $schedule->command('horizon:snapshot')
             ->everyFiveMinutes();
+
+        $schedule->command('passport:purge')
+            ->hourly();
 
         $schedule->command('cleanup:password-resets')
             ->daily();
@@ -65,17 +64,19 @@ class Kernel extends ConsoleKernel
         $schedule->command('donor-perks:reward-currency')
             ->hourly();
 
-        $schedule->command('backup:clean')
-            ->dailyAt('00:00');
+        if (! Environment::isLocalDev()) {
+            $schedule->command('server:query --all')
+                ->everyFiveMinutes();
 
-        $schedule->command('backup:run')
-            ->dailyAt('01:00');
+            $schedule->command('backup:clean')
+                ->dailyAt('00:00');
 
-        $schedule->command('backup:monitor')
-            ->dailyAt('02:00');
+            $schedule->command('backup:run')
+                ->dailyAt('01:00');
 
-        $schedule->command('passport:purge')
-            ->hourly();
+            $schedule->command('backup:monitor')
+                ->dailyAt('02:00');
+        }
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -65,7 +65,7 @@ class Kernel extends ConsoleKernel
             ->hourly();
 
         if (! Environment::isLocalDev()) {
-            $schedule->command('server:query --all')
+            $schedule->command('server:query --all --background')
                 ->everyFiveMinutes();
 
             $schedule->command('backup:clean')

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,8 @@
             "@php artisan vendor:publish --tag=telescope-assets --ansi"
         ],
         "post-update-cmd": [
-            "@php artisan telescope:publish --ansi"
+            "@php artisan telescope:publish --ansi",
+            "@php artisan horizon:publish --ansi"
         ]
     }
 }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -188,6 +188,14 @@ return [
             ],
         ],
 
+        'staging' => [
+            'supervisor-1' => [
+                'maxProcesses' => 5,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+            ],
+        ],
+
         'local' => [
             'supervisor-1' => [
                 'maxProcesses' => 3,

--- a/domain/ServerStatus/Jobs/ServerQueryJob.php
+++ b/domain/ServerStatus/Jobs/ServerQueryJob.php
@@ -23,7 +23,7 @@ final class ServerQueryJob implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        private Server $server
+        private readonly Server $server
     ) {
     }
 
@@ -32,7 +32,9 @@ final class ServerQueryJob implements ShouldQueue
      */
     public function middleware(): array
     {
-        return [new WithoutOverlapping($this->server->getKey())];
+        return [
+            (new WithoutOverlapping($this->server->getKey()))->dontRelease(),
+        ];
     }
 
     /**

--- a/domain/ServerStatus/Jobs/ServerQueryJob.php
+++ b/domain/ServerStatus/Jobs/ServerQueryJob.php
@@ -9,11 +9,15 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 
 final class ServerQueryJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     /**
      * Create a new job instance.
@@ -21,6 +25,14 @@ final class ServerQueryJob implements ShouldQueue
     public function __construct(
         private Server $server
     ) {
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping($this->server->getKey())];
     }
 
     /**

--- a/entities/Notifications/AccountActivationNotification.php
+++ b/entities/Notifications/AccountActivationNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-final class AccountActivationNotification extends Notification
+final class AccountActivationNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountActivationNotification.php
+++ b/entities/Notifications/AccountActivationNotification.php
@@ -25,6 +25,16 @@ final class AccountActivationNotification extends Notification implements Should
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      */
     public function toMail($notifiable): MailMessage

--- a/entities/Notifications/AccountActivationNotification.php
+++ b/entities/Notifications/AccountActivationNotification.php
@@ -30,7 +30,7 @@ final class AccountActivationNotification extends Notification implements Should
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
@@ -32,6 +32,16 @@ class AccountMfaBackupCodeRegeneratedNotification extends Notification implement
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AccountMfaBackupCodeRegeneratedNotification extends Notification
+class AccountMfaBackupCodeRegeneratedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeRegeneratedNotification.php
@@ -37,7 +37,7 @@ class AccountMfaBackupCodeRegeneratedNotification extends Notification implement
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AccountMfaBackupCodeUsedNotification extends Notification
+class AccountMfaBackupCodeUsedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
@@ -37,7 +37,7 @@ class AccountMfaBackupCodeUsedNotification extends Notification implements Shoul
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
+++ b/entities/Notifications/AccountMfaBackupCodeUsedNotification.php
@@ -32,6 +32,16 @@ class AccountMfaBackupCodeUsedNotification extends Notification implements Shoul
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/AccountMfaDisabledNotification.php
+++ b/entities/Notifications/AccountMfaDisabledNotification.php
@@ -32,6 +32,16 @@ class AccountMfaDisabledNotification extends Notification implements ShouldQueue
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/AccountMfaDisabledNotification.php
+++ b/entities/Notifications/AccountMfaDisabledNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AccountMfaDisabledNotification extends Notification
+class AccountMfaDisabledNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountMfaDisabledNotification.php
+++ b/entities/Notifications/AccountMfaDisabledNotification.php
@@ -37,7 +37,7 @@ class AccountMfaDisabledNotification extends Notification implements ShouldQueue
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountMfaEnabledNotification.php
+++ b/entities/Notifications/AccountMfaEnabledNotification.php
@@ -37,7 +37,7 @@ class AccountMfaEnabledNotification extends Notification implements ShouldQueue
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountMfaEnabledNotification.php
+++ b/entities/Notifications/AccountMfaEnabledNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AccountMfaEnabledNotification extends Notification
+class AccountMfaEnabledNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountMfaEnabledNotification.php
+++ b/entities/Notifications/AccountMfaEnabledNotification.php
@@ -32,6 +32,16 @@ class AccountMfaEnabledNotification extends Notification implements ShouldQueue
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/AccountPasswordResetCompleteNotification.php
+++ b/entities/Notifications/AccountPasswordResetCompleteNotification.php
@@ -23,6 +23,16 @@ final class AccountPasswordResetCompleteNotification extends Notification implem
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/AccountPasswordResetCompleteNotification.php
+++ b/entities/Notifications/AccountPasswordResetCompleteNotification.php
@@ -28,7 +28,7 @@ final class AccountPasswordResetCompleteNotification extends Notification implem
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/AccountPasswordResetCompleteNotification.php
+++ b/entities/Notifications/AccountPasswordResetCompleteNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-final class AccountPasswordResetCompleteNotification extends Notification
+final class AccountPasswordResetCompleteNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountPasswordResetNotification.php
+++ b/entities/Notifications/AccountPasswordResetNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-final class AccountPasswordResetNotification extends Notification
+final class AccountPasswordResetNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/AccountPasswordResetNotification.php
+++ b/entities/Notifications/AccountPasswordResetNotification.php
@@ -25,6 +25,16 @@ final class AccountPasswordResetNotification extends Notification implements Sho
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      */
     public function toMail($notifiable): MailMessage

--- a/entities/Notifications/AccountPasswordResetNotification.php
+++ b/entities/Notifications/AccountPasswordResetNotification.php
@@ -30,7 +30,7 @@ final class AccountPasswordResetNotification extends Notification implements Sho
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/BanAppealConfirmationNotification.php
+++ b/entities/Notifications/BanAppealConfirmationNotification.php
@@ -37,6 +37,17 @@ class BanAppealConfirmationNotification extends Notification implements ShouldQu
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+            'discordHook' => 'discord-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable

--- a/entities/Notifications/BanAppealConfirmationNotification.php
+++ b/entities/Notifications/BanAppealConfirmationNotification.php
@@ -6,11 +6,12 @@ use Awssat\Notifications\Messages\DiscordEmbed;
 use Awssat\Notifications\Messages\DiscordMessage;
 use Entities\Models\Eloquent\BanAppeal;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Str;
 
-class BanAppealConfirmationNotification extends Notification
+class BanAppealConfirmationNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/BanAppealConfirmationNotification.php
+++ b/entities/Notifications/BanAppealConfirmationNotification.php
@@ -42,8 +42,8 @@ class BanAppealConfirmationNotification extends Notification implements ShouldQu
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
-            'discordHook' => 'discord-queue',
+            'mail' => 'mail',
+            'discordHook' => 'discord-message',
         ];
     }
 

--- a/entities/Notifications/BanAppealUpdatedNotification.php
+++ b/entities/Notifications/BanAppealUpdatedNotification.php
@@ -38,7 +38,7 @@ class BanAppealUpdatedNotification extends Notification implements ShouldQueue
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/BanAppealUpdatedNotification.php
+++ b/entities/Notifications/BanAppealUpdatedNotification.php
@@ -33,6 +33,16 @@ class BanAppealUpdatedNotification extends Notification implements ShouldQueue
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      * @param  mixed  $notifiable

--- a/entities/Notifications/BanAppealUpdatedNotification.php
+++ b/entities/Notifications/BanAppealUpdatedNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class BanAppealUpdatedNotification extends Notification
+class BanAppealUpdatedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/BuilderRankAppApprovedNotification.php
+++ b/entities/Notifications/BuilderRankAppApprovedNotification.php
@@ -5,10 +5,11 @@ namespace Entities\Notifications;
 use Entities\Models\Eloquent\BuilderRankApplication;
 use Entities\Models\Eloquent\Group;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class BuilderRankAppApprovedNotification extends Notification
+class BuilderRankAppApprovedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/BuilderRankAppApprovedNotification.php
+++ b/entities/Notifications/BuilderRankAppApprovedNotification.php
@@ -41,7 +41,7 @@ class BuilderRankAppApprovedNotification extends Notification implements ShouldQ
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/BuilderRankAppApprovedNotification.php
+++ b/entities/Notifications/BuilderRankAppApprovedNotification.php
@@ -36,6 +36,16 @@ class BuilderRankAppApprovedNotification extends Notification implements ShouldQ
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/BuilderRankAppDeclinedNotification.php
+++ b/entities/Notifications/BuilderRankAppDeclinedNotification.php
@@ -34,6 +34,16 @@ class BuilderRankAppDeclinedNotification extends Notification implements ShouldQ
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/BuilderRankAppDeclinedNotification.php
+++ b/entities/Notifications/BuilderRankAppDeclinedNotification.php
@@ -39,7 +39,7 @@ class BuilderRankAppDeclinedNotification extends Notification implements ShouldQ
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/BuilderRankAppDeclinedNotification.php
+++ b/entities/Notifications/BuilderRankAppDeclinedNotification.php
@@ -4,10 +4,11 @@ namespace Entities\Notifications;
 
 use Entities\Models\Eloquent\BuilderRankApplication;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class BuilderRankAppDeclinedNotification extends Notification
+class BuilderRankAppDeclinedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/BuilderRankAppSubmittedNotification.php
+++ b/entities/Notifications/BuilderRankAppSubmittedNotification.php
@@ -38,6 +38,17 @@ class BuilderRankAppSubmittedNotification extends Notification implements Should
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+            'discordHook' => 'discord-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/BuilderRankAppSubmittedNotification.php
+++ b/entities/Notifications/BuilderRankAppSubmittedNotification.php
@@ -6,12 +6,13 @@ use Awssat\Notifications\Messages\DiscordEmbed;
 use Awssat\Notifications\Messages\DiscordMessage;
 use Entities\Models\Eloquent\BuilderRankApplication;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Str;
 use function route;
 
-class BuilderRankAppSubmittedNotification extends Notification
+class BuilderRankAppSubmittedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/BuilderRankAppSubmittedNotification.php
+++ b/entities/Notifications/BuilderRankAppSubmittedNotification.php
@@ -43,8 +43,8 @@ class BuilderRankAppSubmittedNotification extends Notification implements Should
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
-            'discordHook' => 'discord-queue',
+            'mail' => 'mail',
+            'discordHook' => 'discord-message',
         ];
     }
 

--- a/entities/Notifications/DonationEndedNotification.php
+++ b/entities/Notifications/DonationEndedNotification.php
@@ -37,7 +37,7 @@ class DonationEndedNotification extends Notification implements ShouldQueue
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/DonationEndedNotification.php
+++ b/entities/Notifications/DonationEndedNotification.php
@@ -3,10 +3,11 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class DonationEndedNotification extends Notification
+class DonationEndedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/DonationEndedNotification.php
+++ b/entities/Notifications/DonationEndedNotification.php
@@ -32,6 +32,16 @@ class DonationEndedNotification extends Notification implements ShouldQueue
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *

--- a/entities/Notifications/DonationPerkStartedNotification.php
+++ b/entities/Notifications/DonationPerkStartedNotification.php
@@ -42,7 +42,7 @@ class DonationPerkStartedNotification extends Notification implements ShouldQueu
     public function viaQueues(): array
     {
         return [
-            'mail' => 'mail-queue',
+            'mail' => 'mail',
         ];
     }
 

--- a/entities/Notifications/DonationPerkStartedNotification.php
+++ b/entities/Notifications/DonationPerkStartedNotification.php
@@ -3,12 +3,13 @@
 namespace Entities\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Carbon;
 use function route;
 
-class DonationPerkStartedNotification extends Notification
+class DonationPerkStartedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/entities/Notifications/DonationPerkStartedNotification.php
+++ b/entities/Notifications/DonationPerkStartedNotification.php
@@ -37,6 +37,16 @@ class DonationPerkStartedNotification extends Notification implements ShouldQueu
     }
 
     /**
+     * Determine which queues should be used for each notification channel.
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+        ];
+    }
+
+    /**
      * Get the mail representation of the notification.
      *
      *


### PR DESCRIPTION
## Overview of Changes

* Sends notifications (emails and discord messages) on a queue instead of blocking. Mail and Discord are different queues
* Always sends server status queries on a specific queue
* Adjusts Horizon - generating metrics and adjusting config

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
