### PR TITLE
Fix error when storing failed job

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -80,15 +80,9 @@ return [
     */
 
     'failed' => [
+        'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
         'database' => env('DB_CONNECTION', 'mysql'),
         'table' => 'failed_jobs',
-
-        // Force Laravel to use `DatabaseUuidFailedJobProvider` instead of the
-        // default `DatabaseFailedJobProvider`, which isn't compatible with the
-        // failed jobs table schema Laravel provided us
-        //
-        // https://laracasts.com/discuss/channels/lumen/uuid-on-queue-failed-jobs-is-empty
-        'driver' => 'database-uuids',
     ],
 
 ];

--- a/config/queue.php
+++ b/config/queue.php
@@ -82,6 +82,13 @@ return [
     'failed' => [
         'database' => env('DB_CONNECTION', 'mysql'),
         'table' => 'failed_jobs',
+
+        // Force Laravel to use `DatabaseUuidFailedJobProvider` instead of the
+        // default `DatabaseFailedJobProvider`, which isn't compatible with the
+        // failed jobs table schema Laravel provided us
+        //
+        // https://laracasts.com/discuss/channels/lumen/uuid-on-queue-failed-jobs-is-empty
+        'driver' => 'database-uuids',
     ],
 
 ];


### PR DESCRIPTION
## Overview of Changes
Fixes the exception being thrown when a job fails

```
SQLSTATE[HY000]: General error: 1364 Field 'uuid' doesn't have a default value
````

Our config was missing a key for `driver`, which exists in the default config file
https://github.com/laravel/laravel/blob/9.x/config/queue.php

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
