### PR TITLE
Fix exception thrown when pinging the server

### DIFF
--- a/domain/ServerStatus/Adapters/MinecraftQueryAdapter.php
+++ b/domain/ServerStatus/Adapters/MinecraftQueryAdapter.php
@@ -18,6 +18,10 @@ final class MinecraftQueryAdapter implements ServerQueryAdapter
 
             Log::debug('Successfully pinged server', ['response' => $response]);
 
+            if ($response === false) {
+                return ServerQueryResult::offline();
+            }
+
             $players = $response['players'];
 
             return ServerQueryResult::online(


### PR DESCRIPTION
## Overview of Changes
Sometimes the response from pinging the server is `{ "response": false }`.
This adds handling to treat it as offline

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
