### PR TITLE
Add command to manually test 3rd party services

### DIFF
--- a/app/Console/Commands/TestServiceCommand.php
+++ b/app/Console/Commands/TestServiceCommand.php
@@ -23,6 +23,7 @@ final class TestServiceCommand extends Command
         $service = $this->option('service');
         if (count($service) === 0) {
             $this->error('You must specify a service to test with --service=xxx');
+
             return;
         }
 
@@ -39,7 +40,7 @@ final class TestServiceCommand extends Command
                 break;
 
             default:
-                $this->error($serviceName . 'is not a recognised service');
+                $this->error($serviceName.'is not a recognised service');
                 break;
         }
     }

--- a/app/Console/Commands/TestServiceCommand.php
+++ b/app/Console/Commands/TestServiceCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Library\Logging\VerifyTailLogIntegration;
+use Library\Sentry\VerifySentryIntegration;
+
+final class TestServiceCommand extends Command
+{
+    public function __construct(
+        private VerifyTailLogIntegration $verifyTailLogIntegration,
+        private VerifySentryIntegration $verifySentryIntegration,
+    ) {
+        parent::__construct();
+    }
+
+    protected $signature = 'test:service {--service=*}';
+    protected $description = 'Tests the given 3rd-party service';
+
+    public function handle()
+    {
+        $service = $this->option('service');
+        if (count($service) === 0) {
+            $this->error('You must specify a service to test with --service=xxx');
+            return;
+        }
+
+        $serviceName = strtolower($service[0]);
+        switch ($serviceName) {
+            case 'logtail':
+                $this->verifyTailLogIntegration->sendTestLog();
+                $this->info('Sent `Hello World` test log to LogTail');
+                break;
+
+            case 'sentry':
+                $this->verifySentryIntegration->sendTestException();
+                $this->info('Sent test exception to Sentry');
+                break;
+
+            default:
+                $this->error($serviceName . 'is not a recognised service');
+                break;
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,7 @@ use App\Console\Commands\GenerateSitemapCommand;
 use App\Console\Commands\RepairMissingGroupsCommand;
 use App\Console\Commands\RewardCurrencyToDonorsCommand;
 use App\Console\Commands\ServerQueryCommand;
+use App\Console\Commands\TestServiceCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Library\Environment\Environment;
@@ -34,6 +35,7 @@ class Kernel extends ConsoleKernel
         ServerQueryCommand::class,
         AccountCreatedAtImport::class,
         GenerateScoutIndexesCommand::class,
+        TestServiceCommand::class,
     ];
 
     /**

--- a/app/Exceptions/ExceptionHandler.php
+++ b/app/Exceptions/ExceptionHandler.php
@@ -2,11 +2,22 @@
 
 namespace App\Exceptions;
 
+use App\Exceptions\Http\BadRequestException;
 use App\Exceptions\Http\BaseHttpException;
+use App\Exceptions\Http\ForbiddenException;
+use App\Exceptions\Http\NotFoundException;
+use App\Exceptions\Http\TooManyRequestsException;
+use App\Exceptions\Http\UnauthorisedException;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
 
 class ExceptionHandler extends Handler
@@ -17,17 +28,17 @@ class ExceptionHandler extends Handler
      * @var array
      */
     protected $dontReport = [
-        \Illuminate\Auth\AuthenticationException::class,
-        \Illuminate\Auth\Access\AuthorizationException::class,
-        \Symfony\Component\HttpKernel\Exception\HttpException::class,
-        \Illuminate\Database\Eloquent\ModelNotFoundException::class,
-        \Illuminate\Session\TokenMismatchException::class,
-        \Illuminate\Validation\ValidationException::class,
-        \App\Exceptions\Http\UnauthorisedException::class,
-        \App\Exceptions\Http\BadRequestException::class,
-        \App\Exceptions\Http\ForbiddenException::class,
-        \App\Exceptions\Http\NotFoundException::class,
-        \App\Exceptions\Http\TooManyRequestsException::class,
+        AuthenticationException::class,
+        AuthorizationException::class,
+        HttpException::class,
+        ModelNotFoundException::class,
+        TokenMismatchException::class,
+        ValidationException::class,
+        UnauthorisedException::class,
+        BadRequestException::class,
+        ForbiddenException::class,
+        NotFoundException::class,
+        TooManyRequestsException::class,
     ];
 
     /**

--- a/library/Logging/VerifyTailLogIntegration.php
+++ b/library/Logging/VerifyTailLogIntegration.php
@@ -8,7 +8,8 @@ final class VerifyTailLogIntegration
 {
     public function __construct(
         private LogTailLoggerFactory $loggerFactory,
-    ) {}
+    ) {
+    }
 
     /**
      * @throws Exception if source token not set in config
@@ -16,7 +17,7 @@ final class VerifyTailLogIntegration
     public function sendTestLog(): void
     {
         if (empty(config('logging.channels.logtail.source_token'))) {
-            throw new Exception("LogTail source token not set in config");
+            throw new Exception('LogTail source token not set in config');
         }
         $factory = $this->loggerFactory;
         $logger = $factory(config: []);

--- a/library/Logging/VerifyTailLogIntegration.php
+++ b/library/Logging/VerifyTailLogIntegration.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Library\Logging;
+
+use Exception;
+
+final class VerifyTailLogIntegration
+{
+    public function __construct(
+        private LogTailLoggerFactory $loggerFactory,
+    ) {}
+
+    /**
+     * @throws Exception if source token not set in config
+     */
+    public function sendTestLog(): void
+    {
+        if (empty(config('logging.channels.logtail.source_token'))) {
+            throw new Exception("LogTail source token not set in config");
+        }
+        $factory = $this->loggerFactory;
+        $logger = $factory(config: []);
+        $logger->info('Hello World');
+    }
+}

--- a/library/Sentry/VerifySentryIntegration.php
+++ b/library/Sentry/VerifySentryIntegration.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Library\Sentry;
+
+use Exception;
+
+final class VerifySentryIntegration
+{
+    public function sendTestException()
+    {
+        app('sentry')->captureException(
+            new Exception('Sentry integration test. Ignore this')
+        );
+    }
+}


### PR DESCRIPTION
## Overview of Changes
Adds the command `artisan test:service --service=xxx` to manually test a 3rd party service integration.

Currently supports `logtail` and `sentry`.

* `logtail` will send a test log to LogTail
* `sentry` will send a test exception to Sentry

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
