### PR TITLE
Strip dashes from UUID in aggregate endpoint

### DIFF
--- a/app/Http/Controllers/API/v1/MinecraftAggregateController.php
+++ b/app/Http/Controllers/API/v1/MinecraftAggregateController.php
@@ -31,6 +31,9 @@ final class MinecraftAggregateController extends APIController
         $this->validateRequest($request->all(), [
             'ip' => 'ip',
         ]);
+
+        $uuid = str_replace(search: "-", replace: "", subject: $uuid);
+
         $identifier = PlayerIdentifier::minecraftUUID($uuid);
 
         $ban = $getBan->execute(playerIdentifier: $identifier);

--- a/app/Http/Controllers/API/v1/MinecraftAggregateController.php
+++ b/app/Http/Controllers/API/v1/MinecraftAggregateController.php
@@ -32,7 +32,7 @@ final class MinecraftAggregateController extends APIController
             'ip' => 'ip',
         ]);
 
-        $uuid = str_replace(search: "-", replace: "", subject: $uuid);
+        $uuid = str_replace(search: '-', replace: '', subject: $uuid);
 
         $identifier = PlayerIdentifier::minecraftUUID($uuid);
 


### PR DESCRIPTION
## Overview of Changes
Fixes players not being synced on server login, due to dashes not being stripped from incoming UUIDs

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
