### PR TITLE
Add permanent redirects for all info pages

### DIFF
--- a/resources/views/front/components/navbar.blade.php
+++ b/resources/views/front/components/navbar.blade.php
@@ -18,11 +18,11 @@
                     <li>
                         <h5>Information</h5>
                         <ul>
-                            <li><a href="https://portal.projectcitybuild.com/books/rules/page/community-rules">Rules & Guidelines</a></li>
-                            <li><a href="https://portal.projectcitybuild.com/books/player-ranks/page/list-of-ranks">Ranks</a></li>
-                            <li><a href="https://portal.projectcitybuild.com/books/list-of-staff/page/active">Staff</a></li>
-                            <li><a href="https://portal.projectcitybuild.com/books/server-voting/page/server-voting">Vote For Us</a></li>
-                            <li><a href="https://portal.projectcitybuild.com/books/map-archive/page/map-archive">Map Archive</a></li>
+                            <li><a href="{{ route('rules') }}">Rules & Guidelines</a></li>
+                            <li><a href="{{ route('ranks') }}">Ranks</a></li>
+                            <li><a href="{{ route('staff') }}">Staff</a></li>
+                            <li><a href="{{ route('vote') }}">Vote For Us</a></li>
+                            <li><a href="{{ route('map-archive') }}">Map Archive</a></li>
                         </ul>
                     </li>
                     <li>

--- a/resources/views/front/components/sitemap.blade.php
+++ b/resources/views/front/components/sitemap.blade.php
@@ -6,9 +6,9 @@
             <div class="footer-links__category">
                 <h2>Server</h2>
                 <ul>
-                    <li><i class="bullet fas fa-cube"></i> <a href="https://forums.projectcitybuild.com/t/pcb-community-rules/22928">Rules & Guidelines</a></li>
-                    <li><i class="bullet fas fa-cube"></i> <a href="https://forums.projectcitybuild.com/t/pcb-ranks/32812">Ranks</a></li>
-                    <li><i class="bullet fas fa-cube"></i> <a href="https://wiki.projectcitybuild.com/wiki/List_of_Staff_Members">Staff</a></li>
+                    <li><i class="bullet fas fa-cube"></i> <a href="{{ route('rules') }}">Rules & Guidelines</a></li>
+                    <li><i class="bullet fas fa-cube"></i> <a href="{{ route('ranks') }}">Ranks</a></li>
+                    <li><i class="bullet fas fa-cube"></i> <a href="{{ route('staff') }}">Staff</a></li>
                     <li><i class="bullet fas fa-cube"></i> <a href="{{ route('maps') }}" target="_blank" rel="noopener noreferrer">Real-Time Maps</a></li>
                     <li><i class="bullet fas fa-cube"></i> <a href="{{ route('3d-maps') }}" target="_blank" rel="noopener noreferrer">3D Maps</a></li>
                 </ul>
@@ -18,7 +18,7 @@
                 <h2>Community</h2>
                 <ul>
                     <li><i class="bullet fas fa-cube"></i> <a href="{{ route('wiki') }}">Community Wiki</a></li>
-                    <li><i class="bullet fas fa-cube"></i> <a href="https://forums.projectcitybuild.com/t/vote-for-our-server/18568">Vote For Our Server</a></li>
+                    <li><i class="bullet fas fa-cube"></i> <a href="{{ route('vote') }}">Vote For Our Server</a></li>
                 </ul>
             </div>
 

--- a/routes/web_redirects.php
+++ b/routes/web_redirects.php
@@ -34,4 +34,3 @@ Route::permanentRedirect('vote', 'https://portal.projectcitybuild.com/books/serv
 
 Route::permanentRedirect('map-archive', 'https://portal.projectcitybuild.com/books/map-archive/page/map-archive')
     ->name('map-archive');
-

--- a/routes/web_redirects.php
+++ b/routes/web_redirects.php
@@ -2,9 +2,36 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::permanentRedirect('terms', 'https://forums.projectcitybuild.com/t/community-rules/22928')->name('terms');
-Route::permanentRedirect('privacy', 'https://forums.projectcitybuild.com/privacy')->name('privacy');
-Route::permanentRedirect('wiki', 'https://wiki.projectcitybuild.com')->name('wiki');
-Route::permanentRedirect('maps', 'https://maps.pcbmc.co')->name('maps');
-Route::permanentRedirect('3d-maps', 'https://3d.pcbmc.co')->name('3d-maps');
-Route::permanentRedirect('report', 'https://forums.projectcitybuild.com/w/player-report')->name('report');
+Route::permanentRedirect('terms', 'https://forums.projectcitybuild.com/t/community-rules/22928')
+    ->name('terms');
+
+Route::permanentRedirect('privacy', 'https://forums.projectcitybuild.com/privacy')
+    ->name('privacy');
+
+Route::permanentRedirect('wiki', 'https://wiki.projectcitybuild.com')
+    ->name('wiki');
+
+Route::permanentRedirect('maps', 'https://maps.pcbmc.co')
+    ->name('maps');
+
+Route::permanentRedirect('3d-maps', 'https://3d.pcbmc.co')
+    ->name('3d-maps');
+
+Route::permanentRedirect('report', 'https://forums.projectcitybuild.com/w/player-report')
+    ->name('report');
+
+Route::permanentRedirect('rules', 'https://portal.projectcitybuild.com/books/rules/page/community-rules')
+    ->name('rules');
+
+Route::permanentRedirect('ranks', 'https://portal.projectcitybuild.com/books/player-ranks/page/list-of-ranks')
+    ->name('ranks');
+
+Route::permanentRedirect('staff', 'https://portal.projectcitybuild.com/books/list-of-staff/page/active')
+    ->name('staff');
+
+Route::permanentRedirect('vote', 'https://portal.projectcitybuild.com/books/server-voting/page/server-voting')
+    ->name('vote');
+
+Route::permanentRedirect('map-archive', 'https://portal.projectcitybuild.com/books/map-archive/page/map-archive')
+    ->name('map-archive');
+


### PR DESCRIPTION
## Overview of Changes
Adds permanent redirects for all info pages. This allows the server to show these links without being broken if the destination changes in the future

## Deployment Requirements
- [ ] Composer update
- [ ] NPM update
- [ ] Database migration
- [ ] .env update
- [ ] Environment upgrade (eg. PHP version)
- [ ] Other (please specify)
