### PR TITLE
feat: add permanent redirects for login and auth

### DIFF
--- a/routes/web_redirects.php
+++ b/routes/web_redirects.php
@@ -31,3 +31,7 @@ Route::permanentRedirect('map-archive', 'https://portal.projectcitybuild.com/boo
 
 Route::permanentRedirect('3d-maps', 'https://3d.pcbmc.co')
     ->name('3d-maps');
+
+Route::permanentRedirect('login', 'https://projectcitybuild.com/auth/login');
+
+Route::permanentRedirect('register', 'https://projectcitybuild.com/auth/register');


### PR DESCRIPTION
Adds a redirect for `login` -> `auth/login` and `register` -> `auth/register`