### PR TITLE
fix: round playtime badge to 2 decimals

### DIFF
--- a/app/Domains/Badges/UseCases/GetBadges.php
+++ b/app/Domains/Badges/UseCases/GetBadges.php
@@ -10,8 +10,7 @@ final class GetBadges
 {
     public function __construct(
         private readonly PlayerLookup $playerLookup,
-    ) {
-    }
+    ) {}
 
     public function execute(PlayerIdentifier $identifier): array
     {
@@ -25,13 +24,12 @@ final class GetBadges
 
         $badges = $account->badges;
         $accountAgeInYears = $account->created_at->diffInYears(now());
+        $accountAgeInYears = number_format((float)$accountAgeInYears, decimals: 2);
 
-        if ($accountAgeInYears >= 3) {
-            $badge = new Badge();
-            $badge->display_name = $accountAgeInYears.' years on PCB';
-            $badge->unicode_icon = '⌚';
-            $badges->add($badge);
-        }
+        $badge = new Badge();
+        $badge->display_name = $accountAgeInYears.' years on PCB';
+        $badge->unicode_icon = '⌚';
+        $badges->add($badge);
 
         return $badges->toArray();
     }


### PR DESCRIPTION
* Rounds the `XX years on PCB` badge playtime to 2 decimals
* Removes the 3 year minimum requirement to receive the badge